### PR TITLE
Connect frontend to backend memory API

### DIFF
--- a/scoutos-backend/app/main.py
+++ b/scoutos-backend/app/main.py
@@ -1,7 +1,17 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from app.routes import memory, user, agent
 
 app = FastAPI(title="ScoutOSAI Backend")
+
+# Allow all origins during early development. Limit in production.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(memory.router, prefix="/memory")
 app.include_router(user.router, prefix="/user")

--- a/scoutos-frontend/src/components/ChatInterface.tsx
+++ b/scoutos-frontend/src/components/ChatInterface.tsx
@@ -4,11 +4,40 @@ export default function ChatInterface() {
   const [messages, setMessages] = useState<{sender: string, text: string}[]>([]);
   const [input, setInput] = useState('');
 
-  function sendMessage() {
+  async function sendMessage() {
     if (!input.trim()) return;
-    setMessages([...messages, {sender: 'user', text: input}]);
+
+    // Show the user's message immediately
+    setMessages([...messages, { sender: 'user', text: input }]);
+    const userText = input;
     setInput('');
-    // TODO: Connect to backend for AI assistant reply
+
+    // Call the backend to store the memory
+    try {
+      const response = await fetch('http://localhost:8000/memory/add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_id: 1, // Replace with real user/session info
+          content: userText,
+          topic: 'General',
+          tags: [],
+        }),
+      });
+      const data = await response.json();
+
+      // Display confirmation from the API
+      setMessages((msgs) => [
+        ...msgs,
+        { sender: 'assistant', text: data.message || 'Memory saved!' },
+      ]);
+    } catch (err) {
+      console.error(err);
+      setMessages((msgs) => [
+        ...msgs,
+        { sender: 'assistant', text: 'Error saving memory!' },
+      ]);
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- connect chat UI to backend and send memory data to `POST /memory/add`
- enable CORS in FastAPI for development

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687067b08c388322848d608addffd3ca