### PR TITLE
Add root lock file for Node CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "scoutosai",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scoutosai",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "scoutosai",
+  "version": "1.0.0",
+  "description": "ScoutOSAI is split into a FastAPI backend and a React frontend. Docker Compose sets up the backend and a PostgreSQL database.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- initialize a minimal npm project at the repository root
- generate and commit `package-lock.json` for CI steps that run `npm ci`

## Testing
- `pytest -q` in `scoutos-backend`
- `npm test --silent` in `scoutos-frontend`
- `npm ci --silent` at repo root

------
https://chatgpt.com/codex/tasks/task_e_687072de488c8322990636847afad0a7