### PR TITLE
Add memory list UI and memory endpoints

### DIFF
--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -1,6 +1,6 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from pydantic import BaseModel
-from typing import List
+from typing import List, Optional
 
 router = APIRouter()
 
@@ -8,9 +8,35 @@ class MemoryIn(BaseModel):
     user_id: int
     content: str
     topic: str
-    tags: List[str]
+    tags: List[str] = []
+
+# Temporary in-memory store until database integration
+fake_memories: List[dict] = []
+
 
 @router.post("/add")
 def add_memory(mem: MemoryIn):
-    # TODO: Store in database
-    return {"message": "Memory added", "memory": mem}
+    """Add a memory entry for a user."""
+    fake_memories.append(mem.dict())
+    return {"message": "Memory saved!", "memory": mem}
+
+
+@router.get("/list")
+def list_memories(user_id: int = Query(..., description="ID of the user")):
+    """Return all memories for the given user."""
+    return [m for m in fake_memories if m["user_id"] == user_id]
+
+
+@router.get("/search")
+def search_memories(
+    user_id: int,
+    topic: Optional[str] = None,
+    tag: Optional[str] = None,
+):
+    """Search memories for a user filtered by topic or tag."""
+    result = [m for m in fake_memories if m["user_id"] == user_id]
+    if topic:
+        result = [m for m in result if m["topic"] == topic]
+    if tag:
+        result = [m for m in result if tag in m.get("tags", [])]
+    return result

--- a/scoutos-frontend/src/App.tsx
+++ b/scoutos-frontend/src/App.tsx
@@ -1,10 +1,13 @@
 import ChatInterface from './components/ChatInterface';
+import MemoryList from './components/MemoryList';
 import './index.css';
 
 function App() {
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="min-h-screen bg-gray-50">
+      <h1 className="text-3xl font-bold text-center mt-8">ScoutOS Dashboard</h1>
       <ChatInterface />
+      <MemoryList />
     </div>
   );
 }

--- a/scoutos-frontend/src/components/MemoryList.tsx
+++ b/scoutos-frontend/src/components/MemoryList.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+
+export default function MemoryList() {
+  const [memories, setMemories] = useState<any[]>([]);
+  const [topic, setTopic] = useState('');
+
+  useEffect(() => {
+    fetch(`http://localhost:8000/memory/list?user_id=1`)
+      .then(res => res.json())
+      .then(data => setMemories(data));
+  }, []);
+
+  function searchByTopic() {
+    fetch(`http://localhost:8000/memory/search?user_id=1&topic=${topic}`)
+      .then(res => res.json())
+      .then(data => setMemories(data));
+  }
+
+  return (
+    <div className="w-full max-w-xl mx-auto my-8 bg-white rounded-2xl shadow-lg p-4">
+      <h2 className="text-xl font-bold mb-2">Your Memories</h2>
+      <div className="flex mb-4 gap-2">
+        <input
+          className="flex-1 border p-2 rounded-xl"
+          value={topic}
+          onChange={e => setTopic(e.target.value)}
+          placeholder="Search by topic..."
+        />
+        <button className="bg-gray-800 text-white px-4 py-2 rounded-xl" onClick={searchByTopic}>
+          Search
+        </button>
+      </div>
+      <ul>
+        {memories.map((m, i) => (
+          <li key={i} className="mb-2 p-2 rounded-lg bg-gray-100">
+            <div><strong>Topic:</strong> {m.topic}</div>
+            <div>{m.content}</div>
+            <div className="text-sm text-gray-500">{m.tags && m.tags.join(', ')}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement in-memory Memory endpoints in FastAPI backend
- add MemoryList React component for listing & searching
- update dashboard layout to include memory list

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687067f1c3648322a41d10c9140df4e3