### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/asr319/ScoutOSAI/security/code-scanning/1](https://github.com/asr319/ScoutOSAI/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Since the workflow primarily checks out code, installs dependencies, builds the source code, and runs tests, it only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` has the minimal privileges necessary to complete the tasks.

The `permissions` block should be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
