### PR TITLE
Add missing backend dependencies

### DIFF
--- a/scoutos-backend/requirements.txt
+++ b/scoutos-backend/requirements.txt
@@ -6,3 +6,5 @@ psycopg2-binary
 pydantic
 python-dotenv
 httpx
+openai
+argon2-cffi


### PR DESCRIPTION
## Summary
- add `openai` and `argon2-cffi` to backend requirements
- ensure CI installs dependencies from `requirements.txt`

## Testing
- `pip install -r scoutos-backend/requirements.txt`
- `python -m pytest -q` *(fails: syntax error in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_6870a51a299c832291f881b3424cdfe6