### PR TITLE
Fix App component layout

### DIFF
--- a/scoutos-frontend/src/App.tsx
+++ b/scoutos-frontend/src/App.tsx
@@ -1,16 +1,16 @@
 import ChatInterface from './components/ChatInterface';
+import MemoryManager from './components/MemoryManager';
+import { Toaster } from 'react-hot-toast';
 import './index.css';
 
 function App() {
   return (
-<<<<<<< HEAD
-    <div className="min-h-screen bg-gray-100 p-4 space-y-4">
-=======
-    <div className="min-h-screen bg-gray-100 dark:bg-gray-900">
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 p-4">
       <Toaster position="top-right" />
->>>>>>> origin/main
-      <ChatInterface />
-      <MemoryManager />
+      <div className="space-y-4">
+        <ChatInterface />
+        <MemoryManager />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- clean up leftover merge markers in App
- import MemoryManager and Toaster
- wrap ChatInterface and MemoryManager in a single container

## Testing
- `pytest -q` *(fails: invalid syntax in backend memory route)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6870a518fdd483229291353c646547da