### PR TITLE
Default SQLite for missing DB url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           pip install -r scoutos-backend/requirements.txt
           pip install pytest
       - name: Run tests
+        env:
+          DATABASE_URL: sqlite:///./test.db
         run: |
           cd scoutos-backend
           python -m pytest

--- a/scoutos-backend/app/db.py
+++ b/scoutos-backend/app/db.py
@@ -2,9 +2,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 import os
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL", "postgresql://postgres:password@localhost:5432/scoutos"
-)
+env_url = os.getenv("DATABASE_URL")
+DATABASE_URL = env_url if env_url else "sqlite:///./test.db"
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
## Summary
- default to SQLite when `DATABASE_URL` is not provided
- run tests using SQLite by configuring `DATABASE_URL` in CI

## Testing
- `python -m pytest -q` *(fails: `SyntaxError` in `memory.py`)*

------
https://chatgpt.com/codex/tasks/task_e_6870a51bacf083229d2ff7bddc06ee22