### PR TITLE
Fix memory route conflicts

### DIFF
--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Query, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from app.db import SessionLocal
 from app.models.memory import Memory, Base
@@ -10,11 +10,10 @@ import os
 
 router = APIRouter()
 
-fake_memories = []  # Replace with real DB in production
+fake_memories: List[dict] = []  # Replace with real DB in production
 
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
->>>>>>> origin/main
 
 def get_db():
     db = SessionLocal()
@@ -28,10 +27,6 @@ class MemoryIn(BaseModel):
     content: str
     topic: str
     tags: List[str] = []
-
-# Temporary in-memory store until database integration
-fake_memories: List[dict] = []
- = []
 
 
 class MemoryOut(MemoryIn):


### PR DESCRIPTION
## Summary
- clean up merge markers in `memory.py`
- keep one `fake_memories` placeholder
- return created `Memory` instance in `/add`

## Testing
- `pytest -q` *(fails: OperationalError connecting to PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_6870a51808848322a65f4e9f94f3b781