### PR TITLE
Update Node.js workflow defaults

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,6 +4,9 @@
 name: Node.js CI
 permissions:
   contents: read
+defaults:
+  run:
+    working-directory: scoutos-frontend
 
 on:
   push:
@@ -28,6 +31,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+        cache-dependency-path: scoutos-frontend/package-lock.json
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test
+    - run: npm test --if-present


### PR DESCRIPTION
## Summary
- set `defaults.run.working-directory` to **scoutos-frontend**
- cache node modules with `scoutos-frontend/package-lock.json`
- run tests using `npm test --if-present`

## Testing
- `pip install -r scoutos-backend/requirements.txt`
- `pytest -q` *(fails: SyntaxError)*
- `npm test --if-present`
- `cd scoutos-frontend && npm test --if-present`

------
https://chatgpt.com/codex/tasks/task_e_6870a51662d08322bdc959fec2af4485