### PR TITLE
Configure SQLite test DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .env.*
 !.env.example
 .DS_Store
+scoutos-backend/test.db

--- a/scoutos-backend/tests/conftest.py
+++ b/scoutos-backend/tests/conftest.py
@@ -1,0 +1,18 @@
+import os
+
+# Override the database URL so tests use a local SQLite file
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+# Import engine after setting DATABASE_URL so it picks up the test URI
+from app.db import engine
+from app.models.user import Base as UserBase, User
+from app.models.memory import Base as MemoryBase, Memory
+
+# Ensure all tables exist for the test database
+# Copy the user table onto the memory metadata so SQLAlchemy resolves the
+# foreign key correctly during table creation and inserts.
+User.__table__.to_metadata(MemoryBase.metadata)
+MemoryBase.metadata.create_all(bind=engine)
+
+# No fixtures are required here, but this file ensures the test DB is initialised
+

--- a/scoutos-backend/tests/test_memory.py
+++ b/scoutos-backend/tests/test_memory.py
@@ -9,4 +9,4 @@ def test_add_memory():
     data = {"user_id": 1, "content": "test", "topic": "t", "tags": []}
     resp = client.post("/memory/add", json=data)
     assert resp.status_code == 200
-    assert resp.json()["memory"]["content"] == "test"
+    assert resp.json()["content"] == "test"


### PR DESCRIPTION
## Summary
- add conftest to setup SQLite database before tests
- ignore the generated `test.db` file
- fix failing memory test to match API output

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a867c0a88322abc8c4e591df3eed