### PR TITLE
Add placeholder test script for frontend

### DIFF
--- a/scoutos-frontend/package.json
+++ b/scoutos-frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "echo \"No frontend tests yet\""
   },
   "dependencies": {
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- add a simple `test` script in `scoutos-frontend/package.json`

## Testing
- `npm test` in `scoutos-frontend`
- `pytest -q` in `scoutos-backend` *(fails: NoReferencedTableError)*

------
https://chatgpt.com/codex/tasks/task_e_6870a866b8108322bdb0358c86e1add9