### PR TITLE
Add service layers with CRUD logic and tests

### DIFF
--- a/scoutos-backend/app/services/memory_service.py
+++ b/scoutos-backend/app/services/memory_service.py
@@ -1,6 +1,52 @@
 # Placeholder for memory-related business logic
 
+from sqlalchemy.orm import Session
+from app.models.memory import Memory
+
+
 class MemoryService:
-    def add_memory(self, memory_data):
-        # TODO: Implement database integration
-        return memory_data
+    """Service layer for CRUD operations on ``Memory`` objects."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def add_memory(self, memory_data: dict) -> Memory:
+        """Create and persist a ``Memory``."""
+
+        db_mem = Memory(**memory_data)
+        self.db.add(db_mem)
+        self.db.commit()
+        self.db.refresh(db_mem)
+        return db_mem
+
+    def get_memory(self, memory_id: int) -> Memory | None:
+        """Retrieve a ``Memory`` by primary key."""
+
+        return self.db.query(Memory).get(memory_id)
+
+    def list_memories(self, user_id: int) -> list[Memory]:
+        """Return all memories for a user."""
+
+        return self.db.query(Memory).filter(Memory.user_id == user_id).all()
+
+    def update_memory(self, memory_id: int, update_data: dict) -> Memory | None:
+        """Update fields on a ``Memory`` and persist the changes."""
+
+        mem = self.get_memory(memory_id)
+        if mem is None:
+            return None
+        for key, value in update_data.items():
+            setattr(mem, key, value)
+        self.db.commit()
+        self.db.refresh(mem)
+        return mem
+
+    def delete_memory(self, memory_id: int) -> bool:
+        """Delete a ``Memory`` by id."""
+
+        mem = self.get_memory(memory_id)
+        if mem is None:
+            return False
+        self.db.delete(mem)
+        self.db.commit()
+        return True

--- a/scoutos-backend/app/services/user_service.py
+++ b/scoutos-backend/app/services/user_service.py
@@ -1,6 +1,28 @@
 # Placeholder for user-related business logic
 
+from sqlalchemy.orm import Session
+from argon2 import PasswordHasher
+from app.models.user import User
+
+
 class UserService:
-    def create_user(self, user_data):
-        # TODO: Implement database integration
-        return user_data
+    """Service layer for ``User`` creation and lookup."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+        self.pw_hasher = PasswordHasher()
+
+    def create_user(self, user_data: dict) -> User:
+        """Create a new ``User`` with a hashed password."""
+
+        hashed = self.pw_hasher.hash(user_data["password"])
+        db_user = User(username=user_data["username"], password_hash=hashed)
+        self.db.add(db_user)
+        self.db.commit()
+        self.db.refresh(db_user)
+        return db_user
+
+    def get_by_username(self, username: str) -> User | None:
+        """Retrieve a ``User`` by username."""
+
+        return self.db.query(User).filter(User.username == username).first()

--- a/scoutos-backend/tests/test_memory.py
+++ b/scoutos-backend/tests/test_memory.py
@@ -9,4 +9,4 @@ def test_add_memory():
     data = {"user_id": 1, "content": "test", "topic": "t", "tags": []}
     resp = client.post("/memory/add", json=data)
     assert resp.status_code == 200
-    assert resp.json()["content"] == "test"
+    assert resp.json()["memory"]["content"] == "test"

--- a/scoutos-backend/tests/test_services.py
+++ b/scoutos-backend/tests/test_services.py
@@ -1,0 +1,45 @@
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from app.db import SessionLocal
+from app.services.user_service import UserService
+from app.services.memory_service import MemoryService
+import uuid
+
+
+def test_user_service_create_and_get():
+    db = SessionLocal()
+    service = UserService(db)
+    username = f"alice_{uuid.uuid4().hex[:8]}"
+    user = service.create_user({"username": username, "password": "secret"})
+
+    assert user.id is not None
+    assert user.password_hash != "secret"
+    fetched = service.get_by_username(username)
+    assert fetched.id == user.id
+    db.close()
+
+
+def test_memory_service_crud():
+    db = SessionLocal()
+    user_service = UserService(db)
+    username = f"bob_{uuid.uuid4().hex[:8]}"
+    user = user_service.create_user({"username": username, "password": "pw"})
+
+    mem_service = MemoryService(db)
+    mem = mem_service.add_memory({"user_id": user.id, "content": "c", "topic": "t", "tags": []})
+
+    assert mem.id is not None
+    fetched = mem_service.get_memory(mem.id)
+    assert fetched.content == "c"
+
+    mem_service.update_memory(mem.id, {"content": "new"})
+    updated = mem_service.get_memory(mem.id)
+    assert updated.content == "new"
+
+    listed = mem_service.list_memories(user.id)
+    assert any(m.id == mem.id for m in listed)
+
+    assert mem_service.delete_memory(mem.id) is True
+    assert mem_service.get_memory(mem.id) is None
+    db.close()


### PR DESCRIPTION
## Summary
- implement CRUD methods for `MemoryService`
- implement user creation with password hashing and lookup in `UserService`
- fix memory route test and add tests for new service functionality

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870ad73095c8322b59cf7e6e0789ff8