### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ ScoutOSAI is split into a FastAPI backend and a React frontend. Docker Compose s
 
 ## Getting Started
 
+Run the setup script to install backend and frontend dependencies:
+
+```bash
+./setup.sh
+```
+
+
 ### Backend
 1. Install dependencies:
    ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+cd scoutos-backend && pip install -r requirements.txt
+cd ../scoutos-frontend && npm install
+


### PR DESCRIPTION
## Summary
- add a setup.sh helper script
- document running setup script in README

## Testing
- `./setup.sh`
- `python -m pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870b0e6ccdc8322afa1884c61cf5958