### PR TITLE
Fix default tags field

### DIFF
--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from app.db import SessionLocal
 from app.models.memory import Memory
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Optional
 import datetime
 import openai
@@ -26,7 +26,7 @@ class MemoryIn(BaseModel):
     user_id: int
     content: str
     topic: str
-    tags: List[str] = []
+    tags: List[str] = Field(default_factory=list)
 
 
 class MemoryOut(MemoryIn):


### PR DESCRIPTION
## Summary
- use Field(default_factory=list) for tags in MemoryIn
- adjust import for pydantic Field
- run test suite

## Testing
- `PYTHONPATH=scoutos-backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b236406c8322bf7eb691a8a31bd6