### PR TITLE
Fix memory API serialization and pin httpx

### DIFF
--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -27,6 +27,9 @@ class MemoryOut(MemoryIn):
     id: int
     timestamp: datetime.datetime
 
+    class Config:
+        orm_mode = True
+
 
 class MemorySavedResponse(BaseModel):
     message: str

--- a/scoutos-backend/requirements.txt
+++ b/scoutos-backend/requirements.txt
@@ -5,6 +5,6 @@ asyncpg
 psycopg2-binary
 pydantic
 python-dotenv
-httpx
+httpx<0.28
 openai
 argon2-cffi


### PR DESCRIPTION
## Summary
- set `orm_mode` so Pydantic can serialize `Memory` objects
- pin `httpx` below 0.28 to keep FastAPI tests working

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b194a0f88322b6b8d06136953b15