### PR TITLE
Add backend dev requirements and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          pip install -r scoutos-backend/requirements.txt
-          pip install pytest
+          pip install -r scoutos-backend/requirements.txt -r scoutos-backend/requirements-dev.txt
       - name: Run tests
         env:
           DATABASE_URL: sqlite:///./test.db

--- a/scoutos-backend/README.md
+++ b/scoutos-backend/README.md
@@ -37,7 +37,12 @@ host environment.
 
 ## Tests
 
-Run `pytest` from this folder to execute the unit tests.
+Install the development requirements before running the unit tests:
+
+```bash
+pip install -r requirements.txt -r requirements-dev.txt
+pytest
+```
 
 Contributions are welcome!  See the repository root `README.md` for more
 information.

--- a/scoutos-backend/requirements-dev.txt
+++ b/scoutos-backend/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-cov


### PR DESCRIPTION
## Summary
- add `requirements-dev.txt` for test-only dependencies
- document dev requirements usage in backend README
- install dev requirements in backend CI

## Testing
- `pip install -r scoutos-backend/requirements.txt -r scoutos-backend/requirements-dev.txt`
- `cd scoutos-backend && python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b2346ee88322858e087f89fa8a53