### PR TITLE
Remove unused fake_memories variable

### DIFF
--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -10,9 +10,6 @@ import os
 
 router = APIRouter()
 
-fake_memories: List[dict] = []  # Replace with real DB in production
-
-
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 def get_db():


### PR DESCRIPTION
## Summary
- remove leftover `fake_memories` list from the memory routes

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b2356e9c8322b7e52a8aa7a45e34