### PR TITLE
Update chat to show saved memory

### DIFF
--- a/scoutos-frontend/src/components/AuthForm.tsx
+++ b/scoutos-frontend/src/components/AuthForm.tsx
@@ -2,7 +2,12 @@ import React, { useState } from "react";
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 
-export default function AuthForm({ onAuth }: { onAuth: (user: any) => void }) {
+interface User {
+  id: number;
+  username: string;
+}
+
+export default function AuthForm({ onAuth }: { onAuth: (user: User) => void }) {
   const [mode, setMode] = useState("login");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");

--- a/scoutos-frontend/src/components/ChatInterface.tsx
+++ b/scoutos-frontend/src/components/ChatInterface.tsx
@@ -1,5 +1,14 @@
 import { useState } from "react";
 
+interface Memory {
+  id: number;
+  user_id: number;
+  content: string;
+  topic: string;
+  tags: string[];
+  timestamp: string;
+}
+
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
 
 export default function ChatInterface() {
@@ -26,11 +35,15 @@ export default function ChatInterface() {
         }),
       });
       const data = await response.json();
+      const saved: Memory | undefined = data.memory;
 
-      // Display confirmation from the API
+      // Display confirmation from the API using returned memory data
+      const confirmation = saved
+        ? `Memory "${saved.content}" saved (id ${saved.id}).`
+        : 'Memory saved!';
       setMessages((msgs) => [
         ...msgs,
-        { sender: 'assistant', text: data.message || 'Memory saved!' },
+        { sender: 'assistant', text: confirmation },
       ]);
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- update ChatInterface to parse the `memory` field from POST responses
- display memory info after saving
- define a `User` interface in AuthForm for lint compliance

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870b2337eb08322849816f9ccbe6d76