### PR TITLE
Fix tests with httpx pin and path

### DIFF
--- a/scoutos-backend/requirements.txt
+++ b/scoutos-backend/requirements.txt
@@ -5,6 +5,6 @@ asyncpg
 psycopg2-binary
 pydantic
 python-dotenv
-httpx
+httpx<0.25
 openai
 argon2-cffi

--- a/scoutos-backend/tests/conftest.py
+++ b/scoutos-backend/tests/conftest.py
@@ -1,4 +1,10 @@
 import os
+import sys
+
+# Ensure the backend package is on the Python path when running from the
+# repository root. PyTest may invoke this file with a working directory that
+# does not include ``scoutos-backend`` on ``sys.path``.
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 # Override the database URL so tests use a local SQLite file
 os.environ["DATABASE_URL"] = "sqlite:///./test.db"


### PR DESCRIPTION
## Summary
- ensure scoutos-backend is discoverable when running tests
- pin httpx to <0.25 for Starlette compatibility

## Testing
- `pytest scoutos-backend/tests/test_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b668669883228545e9d2a46468a0