### PR TITLE
Add user context for frontend

### DIFF
--- a/scoutos-frontend/src/App.tsx
+++ b/scoutos-frontend/src/App.tsx
@@ -1,17 +1,30 @@
 import ChatInterface from './components/ChatInterface';
 import MemoryManager from './components/MemoryManager';
+import AuthForm from './components/AuthForm';
 import { Toaster } from 'react-hot-toast';
+import { UserProvider, useUser } from './context/UserContext';
 import './index.css';
+
+function Main() {
+  const { user } = useUser();
+  return user ? (
+    <div className="space-y-4">
+      <ChatInterface />
+      <MemoryManager />
+    </div>
+  ) : (
+    <AuthForm />
+  );
+}
 
 function App() {
   return (
-    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 p-4">
-      <Toaster position="top-right" />
-      <div className="space-y-4">
-        <ChatInterface />
-        <MemoryManager />
+    <UserProvider>
+      <div className="min-h-screen bg-gray-100 dark:bg-gray-900 p-4">
+        <Toaster position="top-right" />
+        <Main />
       </div>
-    </div>
+    </UserProvider>
   );
 }
 

--- a/scoutos-frontend/src/components/AuthForm.tsx
+++ b/scoutos-frontend/src/components/AuthForm.tsx
@@ -1,13 +1,10 @@
 import React, { useState } from "react";
+import { useUser } from "../context/UserContext";
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 
-interface User {
-  id: number;
-  username: string;
-}
-
-export default function AuthForm({ onAuth }: { onAuth: (user: User) => void }) {
+export default function AuthForm() {
+  const { setUser } = useUser();
   const [mode, setMode] = useState("login");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -23,7 +20,7 @@ export default function AuthForm({ onAuth }: { onAuth: (user: User) => void }) {
     const data = await res.json();
     if (res.ok) {
       setMsg(data.message);
-      onAuth({ username, id: data.id });
+      setUser({ username, id: data.id });
     } else {
       setMsg(data.detail);
     }

--- a/scoutos-frontend/src/components/ChatInterface.tsx
+++ b/scoutos-frontend/src/components/ChatInterface.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useUser } from "../context/UserContext";
 
 interface Memory {
   id: number;
@@ -12,6 +13,7 @@ interface Memory {
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
 
 export default function ChatInterface() {
+  const { user } = useUser();
   const [messages, setMessages] = useState<{ sender: string, text: string }[]>([]);
   const [input, setInput] = useState('');
 
@@ -22,13 +24,15 @@ export default function ChatInterface() {
     const userText = input;
     setInput('');
 
+    if (!user) return;
+
     // Call the backend to store the memory
     try {
       const response = await fetch(`${API_URL}/memory/add`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          user_id: 1, // Replace with real user/session info
+          user_id: user.id,
           content: userText,
           topic: 'General',
           tags: [],

--- a/scoutos-frontend/src/components/MemoryManager.tsx
+++ b/scoutos-frontend/src/components/MemoryManager.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useUser } from "../context/UserContext";
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 
@@ -18,10 +19,11 @@ export default function MemoryManager() {
   const [tags, setTags] = useState("");
   const [searchTopic, setSearchTopic] = useState("");
   const [searchTag, setSearchTag] = useState("");
-  const userId = 1;
+  const { user } = useUser();
 
   async function loadMemories() {
-    const res = await fetch(`${API_URL}/memory/list?user_id=${userId}`);
+    if (!user) return;
+    const res = await fetch(`${API_URL}/memory/list?user_id=${user.id}`);
     if (res.ok) {
       const data = await res.json();
       setMemories(data);
@@ -31,11 +33,12 @@ export default function MemoryManager() {
   useEffect(() => { loadMemories(); }, []);
 
   async function addMemory() {
+    if (!user) return;
     const res = await fetch(`${API_URL}/memory/add`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        user_id: userId,
+        user_id: user.id,
         content,
         topic,
         tags: tags.split(',').map(t => t.trim()).filter(t => t)
@@ -51,8 +54,9 @@ export default function MemoryManager() {
   }
 
   async function search() {
+    if (!user) return;
     const params = new URLSearchParams();
-    params.append("user_id", String(userId));
+    params.append("user_id", String(user.id));
     if (searchTopic) params.append("topic", searchTopic);
     if (searchTag) params.append("tag", searchTag);
     const res = await fetch(`${API_URL}/memory/search?${params.toString()}`);

--- a/scoutos-frontend/src/context/UserContext.tsx
+++ b/scoutos-frontend/src/context/UserContext.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+export interface User {
+  id: number;
+  username: string;
+}
+
+interface UserContextType {
+  user: User | null;
+  setUser: (user: User | null) => void;
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export function UserProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  return (
+    <UserContext.Provider value={{ user, setUser }}>
+      {children}
+    </UserContext.Provider>
+  );
+}
+
+export function useUser() {
+  const context = useContext(UserContext);
+  if (context === undefined) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add new `UserContext` for global user state
- use the context in `ChatInterface` and `MemoryManager`
- update `AuthForm` to set the user after authentication
- wrap the app in `UserProvider` and show login form when unauthenticated

## Testing
- `python -m pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870b73f998c832281645a94d1dd837a