### PR TITLE
Use DB-backed user service

### DIFF
--- a/scoutos-backend/app/routes/user.py
+++ b/scoutos-backend/app/routes/user.py
@@ -1,30 +1,40 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
 from argon2 import PasswordHasher
+from app.db import SessionLocal
+from app.services.user_service import UserService
 
 router = APIRouter()
 
-fake_users = []  # Replace with real DB in production
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 class UserIn(BaseModel):
     username: str
     password: str
 
 @router.post("/register")
-def register(user: UserIn):
-    if any(u["username"] == user.username for u in fake_users):
+def register(user: UserIn, db: Session = Depends(get_db)):
+    service = UserService(db)
+    if service.get_by_username(user.username):
         raise HTTPException(status_code=400, detail="Username taken")
-    user_entry = {
-        "username": user.username,
-        "password_hash": PasswordHasher().hash(user.password),
-        "id": len(fake_users) + 1
-    }
-    fake_users.append(user_entry)
-    return {"message": "User registered", "id": user_entry["id"]}
+    new_user = service.create_user({"username": user.username, "password": user.password})
+    return {"message": "User registered", "id": new_user.id}
 
 @router.post("/login")
-def login(user: UserIn):
-    for u in fake_users:
-        if u["username"] == user.username and PasswordHasher().verify(u["password_hash"], user.password):
-            return {"message": "Login successful", "id": u["id"]}
-    raise HTTPException(status_code=401, detail="Invalid credentials")
+def login(user: UserIn, db: Session = Depends(get_db)):
+    service = UserService(db)
+    db_user = service.get_by_username(user.username)
+    if not db_user:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    try:
+        service.pw_hasher.verify(db_user.password_hash, user.password)
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    return {"message": "Login successful", "id": db_user.id}
+

--- a/scoutos-backend/tests/conftest.py
+++ b/scoutos-backend/tests/conftest.py
@@ -1,4 +1,5 @@
-import os
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 # Override the database URL so tests use a local SQLite file
 os.environ["DATABASE_URL"] = "sqlite:///./test.db"

--- a/scoutos-backend/tests/test_services.py
+++ b/scoutos-backend/tests/test_services.py
@@ -20,6 +20,16 @@ def test_user_service_create_and_get():
     db.close()
 
 
+def test_user_service_password_verify():
+    db = SessionLocal()
+    service = UserService(db)
+    username = f"charlie_{uuid.uuid4().hex[:8]}"
+    user = service.create_user({"username": username, "password": "secret"})
+
+    assert service.pw_hasher.verify(user.password_hash, "secret")
+    db.close()
+
+
 def test_memory_service_crud():
     db = SessionLocal()
     user_service = UserService(db)

--- a/scoutos-backend/tests/test_user.py
+++ b/scoutos-backend/tests/test_user.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+import sys, os, uuid
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_register_and_login():
+    username = f"u_{uuid.uuid4().hex[:8]}"
+    password = "pw"
+
+    resp = client.post("/user/register", json={"username": username, "password": password})
+    assert resp.status_code == 200
+    user_id = resp.json()["id"]
+
+    resp = client.post("/user/login", json={"username": username, "password": password})
+    assert resp.status_code == 200
+    assert resp.json()["id"] == user_id
+


### PR DESCRIPTION
## Summary
- delegate user routes to `UserService`
- add test coverage for registration/login
- verify password hashing
- make tests import app in `conftest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b73b9a9c8322a9ae1456ee0159d6