### PR TITLE
Remove unused OpenAI setup in memory route

### DIFF
--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -1,16 +1,12 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.db import SessionLocal
 from app.models.memory import Memory
 from pydantic import BaseModel, Field
 from typing import List, Optional
 import datetime
-import openai
-import os
 
 router = APIRouter()
-
-openai.api_key = os.getenv("OPENAI_API_KEY")
 
 def get_db():
     db = SessionLocal()


### PR DESCRIPTION
## Summary
- clean up memory route imports
- drop `openai.api_key` configuration

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6870b738ce0c832283d868d40bde232a