### PR TITLE
Fix ReactNode import for TypeScript build

### DIFF
--- a/scoutos-frontend/src/context/UserContext.tsx
+++ b/scoutos-frontend/src/context/UserContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, ReactNode } from 'react';
+import { createContext, useContext, useState, type ReactNode } from 'react';
 
 export interface User {
   id: number;


### PR DESCRIPTION
## Summary
- ensure `ReactNode` is imported as a type-only import in UserContext

## Testing
- `python -m pytest -q`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870be4af53c832290bd16b124eb3331