### PR TITLE
Fix memory response handling

### DIFF
--- a/scoutos-frontend/src/components/MemoryManager.tsx
+++ b/scoutos-frontend/src/components/MemoryManager.tsx
@@ -40,8 +40,8 @@ export default function MemoryManager() {
       })
     });
     if (res.ok) {
-      const mem = await res.json();
-      setMemories([...memories, mem]);
+      const { memory } = await res.json();
+      setMemories([...memories, memory]);
       setContent("");
       setTopic("");
       setTags("");


### PR DESCRIPTION
## Summary
- parse the saved memory from backend response
- append the parsed memory to state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*
- `npm run lint` in `scoutos-frontend` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6870be8e5be08322bab57555387482ec