### PR TITLE
Use Session.get for memory lookups

### DIFF
--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -63,7 +63,7 @@ def search_memories(
 
 @router.delete("/delete/{memory_id}")
 def delete_memory(memory_id: int, db: Session = Depends(get_db)):
-    mem = db.query(Memory).get(memory_id)
+    mem = db.get(Memory, memory_id)
     if not mem:
         raise HTTPException(status_code=404, detail="Memory not found")
     db.delete(mem)

--- a/scoutos-backend/app/services/memory_service.py
+++ b/scoutos-backend/app/services/memory_service.py
@@ -22,7 +22,7 @@ class MemoryService:
     def get_memory(self, memory_id: int) -> Memory | None:
         """Retrieve a ``Memory`` by primary key."""
 
-        return self.db.query(Memory).get(memory_id)
+        return self.db.get(Memory, memory_id)
 
     def list_memories(self, user_id: int) -> list[Memory]:
         """Return all memories for a user."""
@@ -32,7 +32,7 @@ class MemoryService:
     def update_memory(self, memory_id: int, update_data: dict) -> Memory | None:
         """Update fields on a ``Memory`` and persist the changes."""
 
-        mem = self.get_memory(memory_id)
+        mem = self.db.get(Memory, memory_id)
         if mem is None:
             return None
         for key, value in update_data.items():
@@ -44,7 +44,7 @@ class MemoryService:
     def delete_memory(self, memory_id: int) -> bool:
         """Delete a ``Memory`` by id."""
 
-        mem = self.get_memory(memory_id)
+        mem = self.db.get(Memory, memory_id)
         if mem is None:
             return False
         self.db.delete(mem)


### PR DESCRIPTION
## Summary
- modernize memory retrieval by using `Session.get`
- call `db.get` in memory service and route

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870bef3a7a48322ac35af755001263d