### PR TITLE
Configure CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Run the setup script to install backend and frontend dependencies:
    ```bash
    export OPENAI_API_KEY=<your-key>
    ```
-3. Start the API:
+3. *(Optional)* Set `ALLOWED_ORIGINS` with a comma-separated list of allowed
+   origins for CORS. The default is `http://localhost:5173`.
+4. Start the API:
    ```bash
    uvicorn app.main:app --reload
    ```

--- a/scoutos-backend/README.md
+++ b/scoutos-backend/README.md
@@ -18,7 +18,8 @@ uvicorn app.main:app --reload
 ```
 
 The service reads the `DATABASE_URL` environment variable to connect to
-PostgreSQL.
+PostgreSQL. Allowed CORS origins can be set with the `ALLOWED_ORIGINS`
+environment variable (comma separated).
 
 ## API Endpoints
 

--- a/scoutos-backend/app/main.py
+++ b/scoutos-backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+import os
 from app.routes import memory, user, agent, ai
 from app.db import engine
 from app.models.base import Base
@@ -8,9 +9,15 @@ from app.models import memory as memory_model, user as user_model
 app = FastAPI(title="ScoutOSAI Backend")
 
 # Allow all origins during early development. Limit in production.
+origins_env = os.getenv("ALLOWED_ORIGINS")
+if origins_env:
+    allowed_origins = [o.strip() for o in origins_env.split(',') if o.strip()]
+else:
+    allowed_origins = ["http://localhost:5173"]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- restrict CORS origins through `ALLOWED_ORIGINS` environment variable
- document the new option in the root README and backend README

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870bf07ac4c8322a583e44faf1fab9d