### PR TITLE
Implement memory update and merge support

### DIFF
--- a/scoutos-backend/app/routes/agent.py
+++ b/scoutos-backend/app/routes/agent.py
@@ -1,7 +1,33 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from typing import List
+from app.db import SessionLocal
+from app.services.memory_service import MemoryService
 
 router = APIRouter()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 @router.get("/status")
 def agent_status():
     return {"status": "Agent module placeholder"}
+
+
+class MergeRequest(BaseModel):
+    user_id: int
+    memory_ids: List[int] = Field(default_factory=list)
+
+
+@router.post("/merge")
+def merge_memories(req: MergeRequest, db=Depends(get_db)):
+    service = MemoryService(db)
+    merged = service.merge_memories(req.memory_ids, req.user_id)
+    if not merged:
+        raise HTTPException(status_code=404, detail="Memories not found")
+    return {"memory": merged}

--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.db import SessionLocal
 from app.models.memory import Memory
+from app.services.memory_service import MemoryService
 from pydantic import BaseModel, Field
 from typing import List, Optional
 import datetime
@@ -69,3 +70,12 @@ def delete_memory(memory_id: int, db: Session = Depends(get_db)):
     db.delete(mem)
     db.commit()
     return {"detail": "Memory deleted"}
+
+
+@router.put("/update/{memory_id}")
+def update_memory(memory_id: int, mem: MemoryIn, db: Session = Depends(get_db)):
+    service = MemoryService(db)
+    updated = service.update_memory(memory_id, mem.dict())
+    if not updated:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return {"memory": updated}

--- a/scoutos-backend/tests/test_agent.py
+++ b/scoutos-backend/tests/test_agent.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_merge_endpoint():
+    d1 = {"user_id": 1, "content": "a", "topic": "t", "tags": ["x"]}
+    d2 = {"user_id": 1, "content": "b", "topic": "t", "tags": ["y"]}
+    r1 = client.post("/memory/add", json=d1)
+    r2 = client.post("/memory/add", json=d2)
+    ids = [r1.json()["memory"]["id"], r2.json()["memory"]["id"]]
+    resp = client.post("/agent/merge", json={"user_id": 1, "memory_ids": ids})
+    assert resp.status_code == 200
+    body = resp.json()["memory"]
+    assert "a" in body["content"] and "b" in body["content"]
+    assert set(body["tags"]) == {"x", "y"}

--- a/scoutos-backend/tests/test_memory.py
+++ b/scoutos-backend/tests/test_memory.py
@@ -10,3 +10,14 @@ def test_add_memory():
     resp = client.post("/memory/add", json=data)
     assert resp.status_code == 200
     assert resp.json()["memory"]["content"] == "test"
+
+
+def test_update_memory():
+    data = {"user_id": 1, "content": "init", "topic": "t", "tags": []}
+    resp = client.post("/memory/add", json=data)
+    memory_id = resp.json()["memory"]["id"]
+
+    updated = {"user_id": 1, "content": "updated", "topic": "t", "tags": []}
+    resp = client.put(f"/memory/update/{memory_id}", json=updated)
+    assert resp.status_code == 200
+    assert resp.json()["memory"]["content"] == "updated"


### PR DESCRIPTION
## Summary
- allow updating memories via `/memory/update`
- add merge endpoint for `/agent/merge`
- support merging memories in `MemoryService`
- test new endpoints and service

## Testing
- `python -m pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870c143754c83229461fcf35b439a79