### PR TITLE
Update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Run the setup script to install backend and frontend dependencies:
 1. Install dependencies:
    ```bash
    cd scoutos-backend
-   pip install -r requirements.txt
+   pip install -r requirements.txt -r requirements-dev.txt
    ```
 2. Set your OpenAI API key as an environment variable before running the app:
    ```bash
@@ -69,6 +69,7 @@ request.
 Tests use `pytest`. After installing dev dependencies, run:
 ```bash
 cd scoutos-backend
+pip install -r requirements.txt -r requirements-dev.txt
 python -m pytest
 ```
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
-cd scoutos-backend && pip install -r requirements.txt
+cd scoutos-backend && pip install -r requirements.txt -r requirements-dev.txt
 cd ../scoutos-frontend && npm install
 


### PR DESCRIPTION
## Summary
- document how to install dev requirements when running backend tests
- adjust backend installation example to match `setup.sh`
- install dev dependencies in `setup.sh`

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870c55dcc7883229d6482542dbb82af