### PR TITLE
Fix Pydantic deprecation in memory update

### DIFF
--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -75,7 +75,7 @@ def delete_memory(memory_id: int, db: Session = Depends(get_db)):
 @router.put("/update/{memory_id}")
 def update_memory(memory_id: int, mem: MemoryIn, db: Session = Depends(get_db)):
     service = MemoryService(db)
-    updated = service.update_memory(memory_id, mem.dict())
+    updated = service.update_memory(memory_id, mem.model_dump())
     if not updated:
         raise HTTPException(status_code=404, detail="Memory not found")
     return {"memory": updated}


### PR DESCRIPTION
## Summary
- use `model_dump()` rather than deprecated `dict()` when updating a memory
- ensure backend tests pass without the Pydantic warning

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870c559bf648322923716129bc618dc