### PR TITLE
Update backend env usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,15 @@ Run the setup script to install backend and frontend dependencies:
    cd scoutos-backend
    pip install -r requirements.txt
    ```
-2. Set your OpenAI API key as an environment variable before running the app:
+2. Copy `.env.example` to `.env` and update credentials if needed:
+   ```bash
+   cp .env.example .env
+   ```
+3. Set your OpenAI API key as an environment variable before running the app:
    ```bash
    export OPENAI_API_KEY=<your-key>
    ```
-3. Start the API:
+4. Start the API:
    ```bash
    uvicorn app.main:app --reload
    ```

--- a/scoutos-backend/.env.example
+++ b/scoutos-backend/.env.example
@@ -1,2 +1,2 @@
-DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/scoutos
+DATABASE_URL=postgresql://user:pass@localhost:5432/scoutos
 OPENAI_API_KEY=sk-...

--- a/scoutos-backend/README.md
+++ b/scoutos-backend/README.md
@@ -7,6 +7,7 @@ for user and memory management.
 
 ```bash
 pip install -r requirements.txt
+cp .env.example .env  # configure DATABASE_URL if needed
 ```
 
 ## Development


### PR DESCRIPTION
## Summary
- switch backend `.env.example` to use the synchronous PostgreSQL driver
- mention copying `.env.example` when setting up the backend
- update backend README with same env copy note

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6870c54b5f94832283956e5164bcd09c