### PR TITLE
refactor: move useUser hook

### DIFF
--- a/scoutos-frontend/src/App.tsx
+++ b/scoutos-frontend/src/App.tsx
@@ -2,7 +2,8 @@ import ChatInterface from './components/ChatInterface';
 import MemoryManager from './components/MemoryManager';
 import AuthForm from './components/AuthForm';
 import { Toaster } from 'react-hot-toast';
-import { UserProvider, useUser } from './context/UserContext';
+import { UserProvider } from './context/UserContext';
+import { useUser } from './hooks/useUser';
 import './index.css';
 
 function Main() {

--- a/scoutos-frontend/src/components/AuthForm.tsx
+++ b/scoutos-frontend/src/components/AuthForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useUser } from "../context/UserContext";
+import { useUser } from "../hooks/useUser";
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 

--- a/scoutos-frontend/src/components/ChatInterface.tsx
+++ b/scoutos-frontend/src/components/ChatInterface.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useUser } from "../context/UserContext";
+import { useUser } from "../hooks/useUser";
 
 interface Memory {
   id: number;

--- a/scoutos-frontend/src/components/MemoryManager.tsx
+++ b/scoutos-frontend/src/components/MemoryManager.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useUser } from "../context/UserContext";
+import { useUser } from "../hooks/useUser";
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 

--- a/scoutos-frontend/src/context/UserContext.tsx
+++ b/scoutos-frontend/src/context/UserContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, type ReactNode } from 'react';
+import { createContext, useState, type ReactNode } from 'react';
 
 export interface User {
   id: number;
@@ -10,7 +10,8 @@ interface UserContextType {
   setUser: (user: User | null) => void;
 }
 
-const UserContext = createContext<UserContextType | undefined>(undefined);
+// eslint-disable-next-line react-refresh/only-export-components
+export const UserContext = createContext<UserContextType | undefined>(undefined);
 
 export function UserProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
@@ -21,10 +22,3 @@ export function UserProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export function useUser() {
-  const context = useContext(UserContext);
-  if (context === undefined) {
-    throw new Error('useUser must be used within a UserProvider');
-  }
-  return context;
-}

--- a/scoutos-frontend/src/hooks/useUser.ts
+++ b/scoutos-frontend/src/hooks/useUser.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { UserContext } from '../context/UserContext';
+
+export function useUser() {
+  const context = useContext(UserContext);
+  if (context === undefined) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- extract `useUser` into its own hook file
- update components to import the new hook
- disable eslint rule on `UserContext` export

## Testing
- `npm run lint` within `scoutos-frontend`
- `npm test` within `scoutos-frontend`
- `python -m pytest` within `scoutos-backend`


------
https://chatgpt.com/codex/tasks/task_e_6870c567baec8322a8f5d475473cfca9