### PR TITLE
Replace deprecated dict() call

### DIFF
--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -76,7 +76,7 @@ def delete_memory(memory_id: int, db: Session = Depends(get_db)):
 @router.put("/update/{memory_id}")
 def update_memory(memory_id: int, mem: MemoryIn, db: Session = Depends(get_db)):
     service = MemoryService(db)
-    updated = service.update_memory(memory_id, mem.dict())
+    updated = service.update_memory(memory_id, mem.model_dump())
     if not updated:
         raise HTTPException(status_code=404, detail="Memory not found")
     return {"memory": updated}


### PR DESCRIPTION
## Summary
- update memory update route to use `model_dump`
- run tests

## Testing
- `pip install -r scoutos-backend/requirements.txt -r scoutos-backend/requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870c564e4888322bd25d89567c344d6