### PR TITLE
Fix frontend test script

### DIFF
--- a/scoutos-frontend/package.json
+++ b/scoutos-frontend/package.json
@@ -8,8 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest",
-    "test": "echo \"No frontend tests yet\""
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- ensure `pnpm test` runs Vitest by removing the placeholder script

## Testing
- `pnpm test` *(fails: ELIFECYCLE due to interactive Vitest run)*
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6870e7f1f0788322ad7b70a81306013b