### PR TITLE
Fix httpx dependency version

### DIFF
--- a/scoutos-backend/requirements.txt
+++ b/scoutos-backend/requirements.txt
@@ -5,7 +5,7 @@ asyncpg==0.30.0
 psycopg2-binary==2.9.10
 pydantic==2.11.7
 python-dotenv==1.1.1
-httpx==0.28.1<0.25<0.28
+httpx>=0.25,<0.29
 openai==1.95.0
 argon2-cffi==25.1.0
 starlette==0.47.1


### PR DESCRIPTION
## Summary
- update httpx in backend requirements file

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt --use-deprecated=legacy-resolver`
- `python -m pytest` *(fails: UserBase not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6870e7ecb9088322a68d68d49819dfc2