### PR TITLE
Fix DB table creation with Base

### DIFF
--- a/scoutos-backend/app/main.py
+++ b/scoutos-backend/app/main.py
@@ -24,8 +24,7 @@ app.add_middleware(
 )
 
 # Create tables if they do not exist
-UserBase.metadata.create_all(bind=engine)
-MemoryBase.metadata.create_all(bind=engine)
+Base.metadata.create_all(bind=engine)
 
 app.include_router(memory.router, prefix="/memory")
 app.include_router(user.router, prefix="/user")


### PR DESCRIPTION
## Summary
- ensure all SQLAlchemy models share the same `Base`
- create all tables using `Base.metadata.create_all`

## Testing
- `pip install fastapi sqlalchemy uvicorn[standard] asyncpg psycopg2-binary pydantic python-dotenv httpx openai argon2-cffi pytest pytest-cov`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870e7eb18ac8322930ba4ae6596a664