### PR TITLE
Bump fastapi to fix starlette conflict

### DIFF
--- a/scoutos-backend/requirements.txt
+++ b/scoutos-backend/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.116.0
+fastapi==0.116.1
 uvicorn[standard]==0.35.0
 sqlalchemy==2.0.41
 asyncpg==0.30.0


### PR DESCRIPTION
## Summary
- bump `fastapi` to 0.116.1 to support `starlette` 0.47.1

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870eb54f91c8322a054995a32b69158