### PR TITLE
Fix starlette version for FastAPI 0.116

### DIFF
--- a/scoutos-backend/requirements.txt
+++ b/scoutos-backend/requirements.txt
@@ -8,4 +8,4 @@ python-dotenv==1.1.1
 httpx>=0.25,<0.29
 openai==1.95.0
 argon2-cffi==25.1.0
-starlette==0.47.1
+starlette==0.46.0


### PR DESCRIPTION
## Summary
- pin `starlette` to version `0.46.0` which is compatible with FastAPI 0.116

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`

------
https://chatgpt.com/codex/tasks/task_e_6871820559ec8322baf5c204d8be1aba