### PR TITLE
Switch setup to pnpm

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,13 +4,16 @@ set -e
 # Determine the repository root based on the script location
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 
+# Ensure pnpm is available
+corepack enable pnpm
+
 # Install backend dependencies (including development requirements)
 cd "$REPO_ROOT/scoutos-backend"
 pip install -r requirements.txt -r requirements-dev.txt
 
 # Install frontend dependencies
 cd "$REPO_ROOT/scoutos-frontend"
-npm install
+pnpm install
 
 # Return to the repository root when finished
 cd "$REPO_ROOT"


### PR DESCRIPTION
## Summary
- enable pnpm via corepack in setup script
- install frontend dependencies with pnpm

## Testing
- `pytest -q` in `scoutos-backend`
- `pnpm exec vitest run` in `scoutos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_687182157eec832282225a9d1c4d9803