### PR TITLE
Adjust starlette requirement

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.analysis.typeCheckingMode": "strict",
-  "gitlens.launchpad.indicator.useColors": true
+  "gitlens.launchpad.indicator.useColors": true,
+  "github-actions.workflows.pinned.refresh.enabled": true,
+  "editor.formatOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,7 @@
 {
-    "python.testing.pytestArgs": [
-        "."
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "python.analysis.typeCheckingMode": "strict"
+  "python.testing.pytestArgs": ["."],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true,
+  "python.analysis.typeCheckingMode": "strict",
+  "gitlens.launchpad.indicator.useColors": true
 }

--- a/scoutos-backend/requirements.txt
+++ b/scoutos-backend/requirements.txt
@@ -8,4 +8,4 @@ python-dotenv==1.1.1
 httpx>=0.25,<0.29
 openai==1.95.0
 argon2-cffi==25.1.0
-starlette>=0.40,<0.47.0
+starlette==0.47.1

--- a/scoutos-backend/requirements.txt
+++ b/scoutos-backend/requirements.txt
@@ -8,4 +8,4 @@ python-dotenv==1.1.1
 httpx>=0.25,<0.29
 openai==1.95.0
 argon2-cffi==25.1.0
-starlette==0.47.1
+starlette>=0.40,<0.47.0


### PR DESCRIPTION
## Summary
- keep Starlette version below 0.47 for FastAPI compatibility

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687181f6ef548322bb0e02319eedf2bb