### PR TITLE
Add AI router to backend

### DIFF
--- a/scoutos-backend/app/main.py
+++ b/scoutos-backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routes import memory, user, agent
+from app.routes import memory, user, agent, ai
 
 app = FastAPI(title="ScoutOSAI Backend")
 
@@ -16,6 +16,7 @@ app.add_middleware(
 app.include_router(memory.router, prefix="/memory")
 app.include_router(user.router, prefix="/user")
 app.include_router(agent.router, prefix="/agent")
+app.include_router(ai.router, prefix="/ai")
 
 @app.get("/")
 async def root():


### PR DESCRIPTION
## Summary
- include the AI routes in the FastAPI application so `/ai/chat` works

## Testing
- `pytest tests/test_ai.py::test_ai_missing_api_key -q`
- `pytest -q` *(fails: AuthenticationError, missing endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_6872e0d2b34083228d27c8cee4be393b