### PR TITLE
Configure CORS origins from env

### DIFF
--- a/scoutos-backend/app/main.py
+++ b/scoutos-backend/app/main.py
@@ -1,13 +1,22 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.routes import memory, user, agent, ai
+import os
 
 app = FastAPI(title="ScoutOSAI Backend")
 
-# Allow all origins during early development. Limit in production.
+# Configure CORS
+origins_env = os.getenv("ALLOWED_ORIGINS")
+allowed_origins: list[str]
+
+if origins_env:
+    allowed_origins = [origin.strip() for origin in origins_env.split(",") if origin.strip()]
+else:
+    allowed_origins = ["http://localhost:5173", "http://localhost:3000"]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- read `ALLOWED_ORIGINS` environment variable in backend
- default to localhost URLs instead of wildcard `*`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872f4c430c083228980e4c8992c575c