### PR TITLE
Refactor search_memories to use SQL filtering

### DIFF
--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -65,11 +65,7 @@ def search_memories(
     db: Session = Depends(get_db),
 ):
     service = MemoryService(db)
-    mems = service.list_memories(user_id)
-    if topic:
-        mems = [m for m in mems if m.topic == topic]
-    if tag:
-        mems = [m for m in mems if m.tags and tag in m.tags]
+    mems = service.search_memories(user_id, topic=topic, tag=tag)
     return [_serialize(m) for m in mems]
 
 

--- a/scoutos-backend/app/services/memory_service.py
+++ b/scoutos-backend/app/services/memory_service.py
@@ -37,6 +37,18 @@ class MemoryService:
 
         return self.db.query(Memory).filter(Memory.user_id == user_id).all()
 
+    def search_memories(
+        self, user_id: int, topic: str | None = None, tag: str | None = None
+    ) -> List[Memory]:
+        """Return ``Memory`` rows filtered by optional topic and tag."""
+
+        query = self.db.query(Memory).filter(Memory.user_id == user_id)
+        if topic:
+            query = query.filter(Memory.topic == topic)
+        if tag:
+            query = query.filter(Memory.tags.contains(tag))
+        return query.all()
+
     def update_memory(self, memory_id: int, updates: dict) -> Memory | None:
         """Update an existing ``Memory`` with provided values."""
 


### PR DESCRIPTION
## Summary
- add `search_memories` to `MemoryService`
- update `/memory/search` endpoint to query DB directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872f4c5bc508322be3babd9aec376ee