### PR TITLE
Validate user in merge_memories

### DIFF
--- a/scoutos-backend/app/services/memory_service.py
+++ b/scoutos-backend/app/services/memory_service.py
@@ -72,6 +72,9 @@ class MemoryService:
         if len(mems) != len(memory_ids):
             return None
 
+        if any(m.user_id != user_id for m in mems):
+            return None
+
         content = "\n".join(m.content for m in mems)
         tags = set()
         for m in mems:

--- a/scoutos-backend/tests/test_services.py
+++ b/scoutos-backend/tests/test_services.py
@@ -71,3 +71,20 @@ def test_memory_service_merge():
     assert mem_service.get_memory(m1.id) is None
     assert mem_service.get_memory(m2.id) is None
     db.close()
+
+
+def test_merge_memories_user_mismatch():
+    db = SessionLocal()
+    user_service = UserService(db)
+    u1 = user_service.create_user({"username": f"u1_{uuid.uuid4().hex[:8]}", "password": "pw"})
+    u2 = user_service.create_user({"username": f"u2_{uuid.uuid4().hex[:8]}", "password": "pw"})
+
+    mem_service = MemoryService(db)
+    m1 = mem_service.add_memory({"user_id": u1.id, "content": "a", "topic": "t", "tags": []})
+    m2 = mem_service.add_memory({"user_id": u2.id, "content": "b", "topic": "t", "tags": []})
+
+    merged = mem_service.merge_memories([m1.id, m2.id], u1.id)
+    assert merged is None
+    assert mem_service.get_memory(m1.id) is not None
+    assert mem_service.get_memory(m2.id) is not None
+    db.close()


### PR DESCRIPTION
## Summary
- check that memory user IDs match before merging
- test merge failure when user IDs don't match

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872f4c658148322842f7ad920f3e77e