### PR TITLE
Handle OpenAI errors asynchronously

### DIFF
--- a/scoutos-backend/app/routes/ai.py
+++ b/scoutos-backend/app/routes/ai.py
@@ -17,13 +17,17 @@ async def ai_chat(req: AIRequest):
     if not openai.api_key:
         raise HTTPException(
             status_code=500,
-            detail="OPENAI_API_KEY environment variable is not set"
+            detail="OPENAI_API_KEY environment variable is not set",
         )
 
-    resp = openai.ChatCompletion.create(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": req.prompt}],
-        max_tokens=200,
-    )
+    try:
+        resp = await openai.ChatCompletion.acreate(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": req.prompt}],
+            max_tokens=200,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"OpenAI request failed: {exc}")
+
     answer = resp.choices[0].message["content"]
     return {"response": answer}

--- a/scoutos-backend/tests/test_ai.py
+++ b/scoutos-backend/tests/test_ai.py
@@ -24,7 +24,11 @@ def test_ai_chat_returns_mocked_text(monkeypatch):
     fake_resp = SimpleNamespace(
         choices=[SimpleNamespace(message={"content": "mocked reply"})]
     )
-    monkeypatch.setattr(openai.ChatCompletion, "create", lambda **_: fake_resp)
+
+    async def fake_acreate(**_: str):
+        return fake_resp
+
+    monkeypatch.setattr(openai.ChatCompletion, "acreate", fake_acreate)
 
     resp = client.post("/ai/chat", json={"prompt": "hi"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- update `ai_chat` to use `ChatCompletion.acreate` and wrap call in try/except
- adjust AI tests to patch `acreate`

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872f4c7124c8322ab9d3e2a192fe946