### PR TITLE
Use context for ChatInterface user ID

### DIFF
--- a/scoutos-frontend/src/components/ChatInterface.tsx
+++ b/scoutos-frontend/src/components/ChatInterface.tsx
@@ -1,13 +1,19 @@
 import { useState } from "react";
+import { useUser } from "../hooks/useUser";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
 
 export default function ChatInterface() {
   const [messages, setMessages] = useState<{sender: string, text: string}[]>([]);
   const [input, setInput] = useState('');
+  const { user } = useUser();
 
   async function sendMessage() {
     if (!input.trim()) return;
+    if (!user) {
+      setMessages([...messages, { sender: 'assistant', text: 'You must be logged in to send messages.' }]);
+      return;
+    }
 
     // Show the user's message immediately
     setMessages([...messages, { sender: 'user', text: input }]);
@@ -20,7 +26,7 @@ export default function ChatInterface() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          user_id: 1, // Replace with real user/session info
+          user_id: user.id,
           content: userText,
           topic: 'General',
           tags: [],

--- a/scoutos-frontend/src/main.tsx
+++ b/scoutos-frontend/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { UserProvider } from './context/UserContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <UserProvider>
+      <App />
+    </UserProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- use `useUser` hook within `ChatInterface` to access current user
- return an error message if the user is not logged in
- submit actual user id in requests
- wrap the application in `UserProvider`

## Testing
- `npm run lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6872f4c5146083229e9acebc041a1e6c