### PR TITLE
Connect ChatInterface to AI endpoint

### DIFF
--- a/scoutos-frontend/src/components/ChatInterface.tsx
+++ b/scoutos-frontend/src/components/ChatInterface.tsx
@@ -40,7 +40,27 @@ export default function ChatInterface() {
         { sender: 'assistant', text: 'Error saving memory!' },
       ]);
     }
-    // TODO: Connect to backend for AI assistant reply
+    // Fetch AI assistant reply
+    try {
+      const res = await fetch(`${API_URL}/ai/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: userText }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setMessages((msgs) => [
+          ...msgs,
+          { sender: 'assistant', text: data.response },
+        ]);
+      }
+    } catch (err) {
+      console.error(err);
+      setMessages((msgs) => [
+        ...msgs,
+        { sender: 'assistant', text: 'Error fetching AI response!' },
+      ]);
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- hook up ChatInterface with the `/ai/chat` endpoint so the assistant replies
- show any errors from the API in the chat

## Testing
- `npx vitest run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872f53839a08322bdd968a5d761c5fe