### PR TITLE
Fix memory routes and timestamp timezone

### DIFF
--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -37,14 +37,14 @@ def _serialize(mem):
 @router.post("/add")
 def add_memory(mem: MemoryIn, db: Session = Depends(get_db)):
     service = MemoryService(db)
-    new_mem = service.add_memory(mem.dict())
+    new_mem = service.add_memory(mem.model_dump())
     return {"message": "Memory added", "memory": _serialize(new_mem)}
 
 
 @router.put("/update/{memory_id}")
 def update_memory(memory_id: int, mem: MemoryIn, db: Session = Depends(get_db)):
     service = MemoryService(db)
-    updated = service.update_memory(memory_id, mem.dict())
+    updated = service.update_memory(memory_id, mem.model_dump())
     if not updated:
         raise HTTPException(status_code=404, detail="Memory not found")
     return {"message": "Memory updated", "memory": _serialize(updated)}

--- a/scoutos-backend/app/services/memory_service.py
+++ b/scoutos-backend/app/services/memory_service.py
@@ -20,7 +20,7 @@ class MemoryService:
             content=memory_data["content"],
             topic=memory_data.get("topic", ""),
             tags=memory_data.get("tags", []),
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         self.db.add(db_mem)
         self.db.commit()
@@ -84,7 +84,7 @@ class MemoryService:
             content=content,
             topic=topic,
             tags=list(tags),
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         self.db.add(merged)
         for m in mems:


### PR DESCRIPTION
## Summary
- use `model_dump()` when passing memory objects in routes
- avoid deprecated `utcnow()` calls in `MemoryService`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872f57658c08322af2f0ba402c5806d