### PR TITLE
Fix import duplicates in user routes

### DIFF
--- a/scoutos-backend/app/routes/user.py
+++ b/scoutos-backend/app/routes/user.py
@@ -1,15 +1,17 @@
+from typing import Any, Dict, Generator
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
-from typing import Any, Dict, Generator
+
 from app.db import SessionLocal
-from app.services.user_service import UserService
 from app.services.auth_service import create_access_token
+from app.services.user_service import UserService
 
 router = APIRouter()
 
 
-def get_db():
+def get_db() -> Generator[Session, None, None]:
     db = SessionLocal()
     try:
         yield db


### PR DESCRIPTION
## Summary
- standardize imports in `user.py`
- annotate `get_db` return type for clarity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873263459b88322a5a714ea4403d687