### PR TITLE
Add memory search and tests

### DIFF
--- a/scoutos-backend/app/services/memory_service.py
+++ b/scoutos-backend/app/services/memory_service.py
@@ -71,15 +71,14 @@ class MemoryService:
         topic: str | None = None,
         tag: str | None = None,
     ) -> List[Memory]:
-        """Search ``Memory`` rows for ``user_id`` optionally filtered by topic or tag."""
+        """Return memories for ``user_id`` optionally filtered by ``topic`` and ``tag``."""
 
         query = self.db.query(Memory).filter(Memory.user_id == user_id)
-        if topic:
+        if topic is not None:
             query = query.filter(Memory.topic == topic)
-        if tag:
+        if tag is not None:
             query = query.filter(Memory.tags.contains([tag]))
-        mems = query.all()
-        return [self._decrypt_mem(m) for m in mems]
+        return [self._decrypt_mem(m) for m in query.all()]
 
     def update_memory(self, memory_id: int, user_id: int, updates: dict) -> Memory | None:
         """Update an existing ``Memory`` with provided values if owned by ``user_id``."""

--- a/scoutos-backend/tests/test_memory.py
+++ b/scoutos-backend/tests/test_memory.py
@@ -130,6 +130,30 @@ def test_search_memory_filters_by_topic_and_tag():
     assert [m["content"] for m in both.json()] == ["b"]
 
 
+def test_search_memory_returns_all_without_filters():
+    user_id, token = _auth()
+
+    mems = [
+        {"content": "a", "topic": "alpha", "tags": ["urgent"]},
+        {"content": "b", "topic": "beta", "tags": ["later"]},
+    ]
+    for m in mems:
+        client.post(
+            "/memory/add",
+            json={"user_id": user_id, **m},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    resp = client.get(
+        "/memory/search",
+        params={"user_id": user_id},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    contents = {m["content"] for m in resp.json()}
+    assert contents == {"a", "b"}
+
+
 def test_delete_memory():
     data = {"user_id": 3, "content": "d", "topic": "t", "tags": []}
     resp = client.post("/memory/add", json=data)


### PR DESCRIPTION
## Summary
- provide helper to search memories with optional topic/tag filters
- cover `/memory/search` in tests when no filters are provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687326283bcc8322973beb204268726f