### PR TITLE
Fix ChatInterface user check

### DIFF
--- a/scoutos-frontend/src/components/ChatInterface.tsx
+++ b/scoutos-frontend/src/components/ChatInterface.tsx
@@ -7,10 +7,9 @@ export default function ChatInterface() {
   const { user } = useUser();
   const [messages, setMessages] = useState<{sender: string, text: string}[]>([]);
   const [input, setInput] = useState('');
-  const { user } = useUser();
 
   async function sendMessage() {
-    if (!input.trim() || !user || !user) return;
+    if (!input.trim() || !user) return;
     if (!user) {
       setMessages([...messages, { sender: 'assistant', text: 'You must be logged in to send messages.' }]);
       return;


### PR DESCRIPTION
## Summary
- remove duplicate `useUser` call in ChatInterface
- simplify sendMessage early return condition

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6873263738bc8322a278f25e28be4eeb