### PR TITLE
Refactor ai route

### DIFF
--- a/scoutos-backend/app/routes/ai.py
+++ b/scoutos-backend/app/routes/ai.py
@@ -24,7 +24,7 @@ async def ai_chat(req: AIRequest) -> Dict[str, str]:
 
     try:
         client = AsyncOpenAI(api_key=api_key)
-        resp = await client.chat.completions.acreate(
+        resp = await client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": req.prompt}],
             max_tokens=200,

--- a/scoutos-backend/tests/test_ai.py
+++ b/scoutos-backend/tests/test_ai.py
@@ -26,12 +26,12 @@ def test_ai_chat_returns_mocked_text(monkeypatch):
         choices=[SimpleNamespace(message=SimpleNamespace(content="mocked reply"))]
     )
 
-    async def fake_acreate(*_: str, **__: str):
+    async def fake_create(*_: str, **__: str):
         return fake_resp
 
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
-            completions=SimpleNamespace(acreate=fake_acreate)
+            completions=SimpleNamespace(create=fake_create)
         )
     )
 


### PR DESCRIPTION
## Summary
- use `client.chat.completions.create` once to avoid double await
- adjust tests for new async call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873299b48a4832298fb26ccd3c77cd5