### PR TITLE
Fix double wrapped UserProvider

### DIFF
--- a/scoutos-frontend/src/App.tsx
+++ b/scoutos-frontend/src/App.tsx
@@ -1,6 +1,5 @@
 import ChatInterface from './components/ChatInterface';
 import AuthForm from './components/AuthForm';
-import { UserProvider } from './context/UserContext';
 import { useUser } from './hooks/useUser';
 import './index.css';
 
@@ -14,9 +13,5 @@ function AppContent() {
 }
 
 export default function App() {
-  return (
-    <UserProvider>
-      <AppContent />
-    </UserProvider>
-  );
+  return <AppContent />;
 }


### PR DESCRIPTION
## Summary
- remove `UserProvider` from `App.tsx` so components are only wrapped once

## Testing
- `pnpm test --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873299e27a88322b99c5328e44335cc