### PR TITLE
Refactor AI client handling

### DIFF
--- a/scoutos-backend/app/routes/ai.py
+++ b/scoutos-backend/app/routes/ai.py
@@ -22,8 +22,9 @@ async def ai_chat(req: AIRequest) -> Dict[str, str]:
             detail="OPENAI_API_KEY environment variable is not set",
         )
 
+    client = AsyncOpenAI(api_key=api_key)
+
     try:
-        client = AsyncOpenAI(api_key=api_key)
         resp = await client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": req.prompt}],


### PR DESCRIPTION
## Summary
- create the `AsyncOpenAI` client before making the request
- keep only one try/except around the OpenAI request

## Testing
- `cd scoutos-backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732bb19f4083228696d44de3b512a7