### PR TITLE
Fix tests imports and cleanup

### DIFF
--- a/scoutos-backend/tests/test_agent.py
+++ b/scoutos-backend/tests/test_agent.py
@@ -1,7 +1,7 @@
-from fastapi.testclient import TestClient
 import os
 import sys
 import uuid
+from fastapi.testclient import TestClient
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from app.main import app  # noqa: E402
 

--- a/scoutos-backend/tests/test_ai.py
+++ b/scoutos-backend/tests/test_ai.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 import os
 import sys
+import openai
 from app.routes import ai as ai_module
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))


### PR DESCRIPTION
## Summary
- reorder imports in test_agent
- add missing openai import in test_ai
- ensure tests run from scratch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732bb7a3948322b55dfcba482a46bc