### PR TITLE
Fix ChatInterface user check

### DIFF
--- a/scoutos-frontend/src/components/ChatInterface.tsx
+++ b/scoutos-frontend/src/components/ChatInterface.tsx
@@ -10,10 +10,6 @@ export default function ChatInterface() {
 
   async function sendMessage() {
     if (!input.trim() || !user) return;
-    if (!user) {
-      setMessages([...messages, { sender: 'assistant', text: 'You must be logged in to send messages.' }]);
-      return;
-    }
 
     // Show the user's message immediately
     setMessages([...messages, { sender: 'user', text: input }]);


### PR DESCRIPTION
## Summary
- remove redundant check for `user`

## Testing
- `pnpm vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68732bb6c0c08322a07f85d4ab740833