### PR TITLE
Refactor OpenAI call error handling

### DIFF
--- a/scoutos-backend/app/routes/ai.py
+++ b/scoutos-backend/app/routes/ai.py
@@ -22,19 +22,18 @@ async def ai_chat(req: AIRequest) -> Dict[str, str]:
             detail="OPENAI_API_KEY environment variable is not set",
         )
 
-    client = AsyncOpenAI(api_key=api_key)
-
     try:
+        client = AsyncOpenAI(api_key=api_key)
         resp = await client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": req.prompt}],
             max_tokens=200,
         )
+        answer = resp.choices[0].message.content
     except Exception as exc:
         raise HTTPException(
             status_code=503,
             detail=f"OpenAI request failed: {exc}",
         )
 
-    answer = resp.choices[0].message.content
     return {"response": answer}


### PR DESCRIPTION
## Summary
- refactor AI route to wrap OpenAI call in a single try/except

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732eae56a0832295c69043c8461954