### PR TITLE
Ensure CI installs backend deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
           python-version: "3.x"
       - name: Install dependencies
         run: |
-          pip install -r scoutos-backend/requirements.txt
+          cd scoutos-backend
+          pip install -r requirements.txt
           pip install pytest
       - name: Run tests
         env:


### PR DESCRIPTION
## Summary
- install backend dependencies from `scoutos-backend` in CI so that `pip install -r requirements.txt` is exercised

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732eb025808322a3bb98c78994c849