### PR TITLE
Fix merge memories tag aggregation

### DIFF
--- a/scoutos-backend/app/services/memory_service.py
+++ b/scoutos-backend/app/services/memory_service.py
@@ -128,9 +128,12 @@ class MemoryService:
         if any(m.user_id != user_id for m in mems):
             return None
 
-        decrypted = [self._decrypt_mem(m) for m in mems]
-        content = "\n".join(m.content for m in decrypted)
-        tags = set()
+        for m in mems:
+            self._decrypt_mem(m)
+
+        content = "\n".join(m.content for m in mems)
+
+        tags: set[str] = set()
         for m in mems:
             tags.update(m.tags or [])
 


### PR DESCRIPTION
## Summary
- avoid referencing the decrypted list when merging memories
- combine all memory tags before storing merged record

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732eaf0804832293615bbcd220cc28