### PR TITLE
Remove duplicate merge mismatch test

### DIFF
--- a/scoutos-backend/tests/test_agent.py
+++ b/scoutos-backend/tests/test_agent.py
@@ -43,11 +43,3 @@ def test_merge_endpoint():
     assert set(body["tags"]) == {"x", "y"}
 
 
-def test_merge_endpoint_unauthorized():
-    d1 = {"user_id": 10, "content": "a", "topic": "t", "tags": []}
-    d2 = {"user_id": 10, "content": "b", "topic": "t", "tags": []}
-    r1 = client.post("/memory/add", json=d1)
-    r2 = client.post("/memory/add", json=d2)
-    ids = [r1.json()["memory"]["id"], r2.json()["memory"]["id"]]
-    resp = client.post("/agent/merge", json={"user_id": 11, "memory_ids": ids})
-    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- drop duplicate merge test for unauthorized access
- keep service-level user mismatch test

## Testing
- `cd scoutos-backend && rm -f test.db && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732eb12bfc8322b72b4226c3996b78