### PR TITLE
Fix ruff issues and tidy imports

### DIFF
--- a/scoutos-backend/app/services/memory_service.py
+++ b/scoutos-backend/app/services/memory_service.py
@@ -12,10 +12,10 @@ from cryptography.fernet import Fernet
 from sqlalchemy.orm import Session
 
 from app.models.memory import Memory
+from app.utils.encryption import encrypt_text, decrypt_text
 
 # Deterministic fallback key so tests work without configuration
 DEFAULT_KEY = b"1OGaT5SwPuHVrxTp1lT7ZnkSeBAkiqdSqsgTbDuSwIs="
-from app.utils.encryption import encrypt_text, decrypt_text
 
 
 class MemoryService:

--- a/scoutos-backend/tests/conftest.py
+++ b/scoutos-backend/tests/conftest.py
@@ -3,7 +3,6 @@ import sys
 from cryptography.fernet import Fernet
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-from cryptography.fernet import Fernet
 
 # Override the database URL so tests use a local SQLite file
 os.environ["DATABASE_URL"] = "sqlite:///./test.db"

--- a/scoutos-backend/tests/test_ai.py
+++ b/scoutos-backend/tests/test_ai.py
@@ -1,7 +1,6 @@
 from fastapi.testclient import TestClient
 import os
 import sys
-import openai
 from app.routes import ai as ai_module
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))

--- a/scoutos-backend/tests/test_cors.py
+++ b/scoutos-backend/tests/test_cors.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from fastapi.testclient import TestClient
 from app.main import app


### PR DESCRIPTION
## Summary
- resolve lint warnings in backend tests
- move encryption import in `memory_service.py`
- ensure ruff passes

## Testing
- `ruff check scoutos-backend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732eb524648322b031e8700f53d248