### PR TITLE
Add auth validation for memory and agent routes

### DIFF
--- a/scoutos-backend/tests/test_agent.py
+++ b/scoutos-backend/tests/test_agent.py
@@ -44,10 +44,25 @@ def test_merge_endpoint():
 
 
 def test_merge_endpoint_unauthorized():
-    d1 = {"user_id": 10, "content": "a", "topic": "t", "tags": []}
-    d2 = {"user_id": 10, "content": "b", "topic": "t", "tags": []}
-    r1 = client.post("/memory/add", json=d1)
-    r2 = client.post("/memory/add", json=d2)
+    user_id, token = _auth()
+    d1 = {"user_id": user_id, "content": "a", "topic": "t", "tags": []}
+    d2 = {"user_id": user_id, "content": "b", "topic": "t", "tags": []}
+    r1 = client.post(
+        "/memory/add",
+        json=d1,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    r2 = client.post(
+        "/memory/add",
+        json=d2,
+        headers={"Authorization": f"Bearer {token}"},
+    )
     ids = [r1.json()["memory"]["id"], r2.json()["memory"]["id"]]
-    resp = client.post("/agent/merge", json={"user_id": 11, "memory_ids": ids})
+
+    other_id, other_token = _auth()
+    resp = client.post(
+        "/agent/merge",
+        json={"user_id": user_id, "memory_ids": ids},
+        headers={"Authorization": f"Bearer {other_token}"},
+    )
     assert resp.status_code == 403

--- a/scoutos-backend/tests/test_memory.py
+++ b/scoutos-backend/tests/test_memory.py
@@ -31,6 +31,17 @@ def test_add_memory():
     assert resp.json()["memory"]["content"] == "test"
 
 
+def test_add_memory_unauthorized():
+    user_id, token = _auth()
+    data = {"user_id": user_id + 1, "content": "bad", "topic": "t", "tags": []}
+    resp = client.post(
+        "/memory/add",
+        json=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+
+
 def test_update_memory():
     user_id, token = _auth()
     data = {"user_id": user_id, "content": "init", "topic": "t", "tags": []}
@@ -52,12 +63,26 @@ def test_update_memory():
 
 
 def test_update_memory_unauthorized():
-    data = {"user_id": 1, "content": "init", "topic": "t", "tags": []}
-    resp = client.post("/memory/add", json=data)
+    user_id, token = _auth()
+    data = {"user_id": user_id, "content": "init", "topic": "t", "tags": []}
+    resp = client.post(
+        "/memory/add",
+        json=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
     memory_id = resp.json()["memory"]["id"]
 
-    updated = {"user_id": 2, "content": "nope", "topic": "t", "tags": []}
-    resp = client.put(f"/memory/update/{memory_id}", json=updated)
+    updated = {
+        "user_id": user_id + 1,
+        "content": "nope",
+        "topic": "t",
+        "tags": [],
+    }
+    resp = client.put(
+        f"/memory/update/{memory_id}",
+        json=updated,
+        headers={"Authorization": f"Bearer {token}"},
+    )
     assert resp.status_code == 403
 
 
@@ -155,18 +180,37 @@ def test_search_memory_returns_all_without_filters():
 
 
 def test_delete_memory():
-    data = {"user_id": 3, "content": "d", "topic": "t", "tags": []}
-    resp = client.post("/memory/add", json=data)
+    user_id, token = _auth()
+    data = {"user_id": user_id, "content": "d", "topic": "t", "tags": []}
+    resp = client.post(
+        "/memory/add",
+        json=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
     memory_id = resp.json()["memory"]["id"]
 
-    resp = client.delete(f"/memory/delete/{memory_id}", params={"user_id": 3})
+    resp = client.delete(
+        f"/memory/delete/{memory_id}",
+        params={"user_id": user_id},
+        headers={"Authorization": f"Bearer {token}"},
+    )
     assert resp.status_code == 200
 
 
 def test_delete_memory_unauthorized():
-    data = {"user_id": 4, "content": "e", "topic": "t", "tags": []}
-    resp = client.post("/memory/add", json=data)
+    user_id, token = _auth()
+    data = {"user_id": user_id, "content": "e", "topic": "t", "tags": []}
+    resp = client.post(
+        "/memory/add",
+        json=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
     memory_id = resp.json()["memory"]["id"]
 
-    resp = client.delete(f"/memory/delete/{memory_id}", params={"user_id": 5})
+    other_id, other_token = _auth()
+    resp = client.delete(
+        f"/memory/delete/{memory_id}",
+        params={"user_id": user_id},
+        headers={"Authorization": f"Bearer {other_token}"},
+    )
     assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- secure memory add/delete endpoints
- verify user_id matches authenticated user for protected endpoints
- require authentication for agent routes
- update memory and agent tests for new auth checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732f1a10448322adcf88a224b51ff7