### PR TITLE
Update user endpoint docs

### DIFF
--- a/scoutos-backend/README.md
+++ b/scoutos-backend/README.md
@@ -42,8 +42,13 @@ Docker Compose reads this file automatically when launching the services.
 | ------ | ------------- | ------------------------- |
 | `GET`  | `/`           | Health check              |
 | `POST` | `/memory/add` | Store a memory (demo)     |
-| `POST` | `/user/create`| Create a user (demo)      |
+| `POST` | `/user/register`| Register a user (demo)    |
+| `POST` | `/user/login` | Obtain auth token         |
 | `GET`  | `/agent/status`| Agent status placeholder |
+
+Authenticate via `/user/login` to receive a `token`. Pass this value in the
+`Authorization` header as `Bearer <token>` when calling protected endpoints
+like `/memory/update`, `/memory/list`, `/memory/search` or any agent routes.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- update `/user/create` to `/user/register`
- document `/user/login` and how to use the returned token

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732f1cd0a88322aad21611d004bf0b