### PR TITLE
Improve login token handling

### DIFF
--- a/scoutos-frontend/src/components/AuthForm.tsx
+++ b/scoutos-frontend/src/components/AuthForm.tsx
@@ -14,19 +14,44 @@ export default function AuthForm() {
 
   async function handleSubmit() {
     setError('');
-    const path = mode === 'login' ? 'login' : 'register';
     try {
-      const res = await fetch(`${API_URL}/user/${path}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password })
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.detail || 'Request failed');
+      let data: { id: number; token: string } | null = null;
+
+      if (mode === 'register') {
+        const registerRes = await fetch(`${API_URL}/user/register`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username, password })
+        });
+        if (!registerRes.ok) {
+          const body = await registerRes.json().catch(() => ({}));
+          throw new Error(body.detail || 'Request failed');
+        }
+
+        const loginRes = await fetch(`${API_URL}/user/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username, password })
+        });
+        if (!loginRes.ok) {
+          const body = await loginRes.json().catch(() => ({}));
+          throw new Error(body.detail || 'Login failed');
+        }
+        data = await loginRes.json();
+      } else {
+        const loginRes = await fetch(`${API_URL}/user/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username, password })
+        });
+        if (!loginRes.ok) {
+          const body = await loginRes.json().catch(() => ({}));
+          throw new Error(body.detail || 'Request failed');
+        }
+        data = await loginRes.json();
       }
-      const data = await res.json();
-      setUser({ id: data.id, username });
+
+      setUser({ id: data.id, username, token: data.token });
       setUsername('');
       setPassword('');
     } catch (err) {


### PR DESCRIPTION
## Summary
- automatically log users in after registration to obtain a token
- include token when setting user state
- update AuthForm tests for new behaviour

## Testing
- `npm run lint`
- `pnpm exec vitest run`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68732eb240508322807a366a4a7781ed