### PR TITLE
Add logout and token handling

### DIFF
--- a/scoutos-frontend/src/components/AuthForm.test.tsx
+++ b/scoutos-frontend/src/components/AuthForm.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, vi, expect, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, vi, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import AuthForm from './AuthForm'
 import { UserContext, type User } from '../context/UserContext'
 
@@ -15,6 +15,10 @@ describe('AuthForm', () => {
   beforeEach(() => {
     vi.resetAllMocks()
   })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    cleanup()
+  })
 
   it('renders inputs', () => {
     const { container } = renderWithProvider(() => {})
@@ -23,7 +27,7 @@ describe('AuthForm', () => {
 
   it('submits login data', async () => {
     const setUser = vi.fn()
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ id: 1 }) })
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ id: 1, token: 'abc' }) })
     vi.stubGlobal('fetch', fetchMock)
 
     renderWithProvider(setUser)
@@ -35,6 +39,9 @@ describe('AuthForm', () => {
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalled()
     })
-    vi.restoreAllMocks()
+    await waitFor(() => {
+      expect(setUser).toHaveBeenCalled()
+    })
+    expect(setUser).toHaveBeenCalledWith({ id: 1, username: 'bob', token: 'abc' })
   })
 })

--- a/scoutos-frontend/src/components/AuthForm.tsx
+++ b/scoutos-frontend/src/components/AuthForm.tsx
@@ -26,7 +26,7 @@ export default function AuthForm() {
         throw new Error(data.detail || 'Request failed');
       }
       const data = await res.json();
-      setUser({ id: data.id, username });
+      setUser({ id: data.id, username, token: data.token });
       setUsername('');
       setPassword('');
     } catch (err) {

--- a/scoutos-frontend/src/components/ChatInterface.tsx
+++ b/scoutos-frontend/src/components/ChatInterface.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useUser } from "../hooks/useUser";
+import LogoutButton from "./LogoutButton";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
 
@@ -74,6 +75,9 @@ export default function ChatInterface() {
 
   return (
     <div className="w-full max-w-xl mx-auto my-8 bg-white rounded-2xl shadow-lg p-4">
+      <div className="flex justify-end mb-2">
+        <LogoutButton />
+      </div>
       <div className="mb-4 h-80 overflow-y-auto">
         {messages.map((msg, i) => (
           <div key={i} className={msg.sender === 'user' ? 'text-right' : 'text-left'}>

--- a/scoutos-frontend/src/components/LogoutButton.test.tsx
+++ b/scoutos-frontend/src/components/LogoutButton.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import LogoutButton from './LogoutButton'
+import { UserContext, type User } from '../context/UserContext'
+
+function renderWithProvider(setUser: (u: User | null) => void) {
+  return render(
+    <UserContext.Provider value={{ user: { id: 1, username: 'bob', token: 'abc' }, setUser }}>
+      <LogoutButton />
+    </UserContext.Provider>
+  )
+}
+
+describe('LogoutButton', () => {
+  it('calls setUser(null) on click', () => {
+    const setUser = vi.fn()
+    const { getByRole } = renderWithProvider(setUser)
+    fireEvent.click(getByRole('button', { name: /logout/i }))
+    expect(setUser).toHaveBeenCalledWith(null)
+  })
+})

--- a/scoutos-frontend/src/components/LogoutButton.tsx
+++ b/scoutos-frontend/src/components/LogoutButton.tsx
@@ -1,0 +1,13 @@
+import { useUser } from '../hooks/useUser';
+
+export default function LogoutButton() {
+  const { setUser } = useUser();
+  return (
+    <button
+      onClick={() => setUser(null)}
+      className="text-sm text-red-600 underline"
+    >
+      Logout
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- store auth token on login
- create LogoutButton and show it in ChatInterface
- update AuthForm and add tests
- add logout tests

## Testing
- `pnpm exec vitest run`
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68732f1b316083229b194ce149cb1bf4