### PR TITLE
Expose OpenAI API key via compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
 POSTGRES_DB=scoutos
 DATABASE_URL=postgresql://postgres:password@db:5432/scoutos
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 
 ## Setup
 
-`docker-compose.yml` expects the database password in the `POSTGRES_PASSWORD`
-environment variable. Set the variable before starting the stack:
+`docker-compose.yml` expects the database password in `POSTGRES_PASSWORD` and
+an OpenAI API key in `OPENAI_API_KEY`. Set these variables before starting the stack:
 
 ```bash
 export POSTGRES_PASSWORD=yourpassword
+export OPENAI_API_KEY=sk-...
 docker-compose up
 ```
 
-The backend service uses this value when constructing `DATABASE_URL`.
+The backend service uses these values when constructing `DATABASE_URL` and when
+calling the OpenAI API for the demo AI endpoints.
 
 ScoutOSAI is a demo full-stack project that pairs a FastAPI backend with a React + Vite frontend. The application exposes a small API for managing user information and storing short text "memories". The web client provides a minimal chat interface for experimenting with the API.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "8000:8000"
     environment:
       - DATABASE_URL=${DATABASE_URL}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
     depends_on:
       - db
   db:

--- a/scoutos-backend/README.md
+++ b/scoutos-backend/README.md
@@ -22,12 +22,12 @@ PostgreSQL. The backend uses SQLAlchemy's **sync** engine so the URL must
 use the standard `postgresql://` scheme (not the `postgresql+asyncpg://`
 variant). Allowed CORS origins are configured with the `ALLOWED_ORIGINS`
 environment variable. Provide a comma–separated list of origins; by default `*`
-is used to allow all origins during development.  Set `OPENAI_API_KEY` for the AI
-demo endpoints.
+is used to allow all origins during development.  Set `OPENAI_API_KEY` so the AI
+demo endpoints can call the OpenAI API.
 
 ### Environment variables
 
-Database credentials are provided via a `.env` file. From the repository root,
+Database credentials and your OpenAI key are provided via a `.env` file. From the repository root,
 copy `.env.example` to `.env` and adjust the values as needed:
 
 ```bash


### PR DESCRIPTION
## Summary
- document POSTGRES and OpenAI variables in example env file
- pass `OPENAI_API_KEY` to backend in `docker-compose.yml`
- explain the OpenAI API key in the root README and backend docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68733484c258832291a0da84fd67fdad