### PR TITLE
Next phase (#238)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
 POSTGRES_DB=scoutos
 DATABASE_URL=postgresql://postgres:password@db:5432/scoutos
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 
 ## Setup
 
-`docker-compose.yml` expects the database password in the `POSTGRES_PASSWORD`
-environment variable. Set the variable before starting the stack:
+`docker-compose.yml` expects the database password in `POSTGRES_PASSWORD` and
+an OpenAI API key in `OPENAI_API_KEY`. Set these variables before starting the stack:
 
 ```bash
 export POSTGRES_PASSWORD=yourpassword
+export OPENAI_API_KEY=sk-...
 docker-compose up
 ```
 
-The backend service uses this value when constructing `DATABASE_URL`.
+The backend service uses these values when constructing `DATABASE_URL` and when
+calling the OpenAI API for the demo AI endpoints.
 
 ScoutOSAI is a demo full-stack project that pairs a FastAPI backend with a React + Vite frontend. The application exposes a small API for managing user information and storing short text "memories". The web client provides a minimal chat interface for experimenting with the API.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "8000:8000"
     environment:
       - DATABASE_URL=${DATABASE_URL}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
     depends_on:
       - db
   db:

--- a/scoutos-backend/README.md
+++ b/scoutos-backend/README.md
@@ -22,12 +22,12 @@ PostgreSQL. The backend uses SQLAlchemy's **sync** engine so the URL must
 use the standard `postgresql://` scheme (not the `postgresql+asyncpg://`
 variant). Allowed CORS origins are configured with the `ALLOWED_ORIGINS`
 environment variable. Provide a comma–separated list of origins; by default `*`
-is used to allow all origins during development.  Set `OPENAI_API_KEY` for the AI
-demo endpoints.
+is used to allow all origins during development.  Set `OPENAI_API_KEY` so the AI
+demo endpoints can call the OpenAI API.
 
 ### Environment variables
 
-Database credentials are provided via a `.env` file. From the repository root,
+Database credentials and your OpenAI key are provided via a `.env` file. From the repository root,
 copy `.env.example` to `.env` and adjust the values as needed:
 
 ```bash
@@ -42,8 +42,13 @@ Docker Compose reads this file automatically when launching the services.
 | ------ | ------------- | ------------------------- |
 | `GET`  | `/`           | Health check              |
 | `POST` | `/memory/add` | Store a memory (demo)     |
-| `POST` | `/user/create`| Create a user (demo)      |
+| `POST` | `/user/register`| Register a user (demo)    |
+| `POST` | `/user/login` | Obtain auth token         |
 | `GET`  | `/agent/status`| Agent status placeholder |
+
+Authenticate via `/user/login` to receive a `token`. Pass this value in the
+`Authorization` header as `Bearer <token>` when calling protected endpoints
+like `/memory/update`, `/memory/list`, `/memory/search` or any agent routes.
 
 ## Deployment
 

--- a/scoutos-backend/tests/test_agent.py
+++ b/scoutos-backend/tests/test_agent.py
@@ -41,3 +41,26 @@ def test_merge_endpoint():
     assert set(body["tags"]) == {"x", "y"}
 
 
+def test_merge_endpoint_unauthorized():
+    user_id, token = _auth()
+    d1 = {"user_id": user_id, "content": "a", "topic": "t", "tags": []}
+    d2 = {"user_id": user_id, "content": "b", "topic": "t", "tags": []}
+    r1 = client.post(
+        "/memory/add",
+        json=d1,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    r2 = client.post(
+        "/memory/add",
+        json=d2,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    ids = [r1.json()["memory"]["id"], r2.json()["memory"]["id"]]
+
+    other_id, other_token = _auth()
+    resp = client.post(
+        "/agent/merge",
+        json={"user_id": user_id, "memory_ids": ids},
+        headers={"Authorization": f"Bearer {other_token}"},
+    )
+    assert resp.status_code == 403

--- a/scoutos-backend/tests/test_memory.py
+++ b/scoutos-backend/tests/test_memory.py
@@ -29,6 +29,17 @@ def test_add_memory():
     assert resp.json()["memory"]["content"] == "test"
 
 
+def test_add_memory_unauthorized():
+    user_id, token = _auth()
+    data = {"user_id": user_id + 1, "content": "bad", "topic": "t", "tags": []}
+    resp = client.post(
+        "/memory/add",
+        json=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+
+
 def test_update_memory():
     user_id, token = _auth()
     data = {"user_id": user_id, "content": "init", "topic": "t", "tags": []}
@@ -50,12 +61,26 @@ def test_update_memory():
 
 
 def test_update_memory_unauthorized():
-    data = {"user_id": 1, "content": "init", "topic": "t", "tags": []}
-    resp = client.post("/memory/add", json=data)
+    user_id, token = _auth()
+    data = {"user_id": user_id, "content": "init", "topic": "t", "tags": []}
+    resp = client.post(
+        "/memory/add",
+        json=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
     memory_id = resp.json()["memory"]["id"]
 
-    updated = {"user_id": 2, "content": "nope", "topic": "t", "tags": []}
-    resp = client.put(f"/memory/update/{memory_id}", json=updated)
+    updated = {
+        "user_id": user_id + 1,
+        "content": "nope",
+        "topic": "t",
+        "tags": [],
+    }
+    resp = client.put(
+        f"/memory/update/{memory_id}",
+        json=updated,
+        headers={"Authorization": f"Bearer {token}"},
+    )
     assert resp.status_code == 403
 
 
@@ -153,18 +178,37 @@ def test_search_memory_returns_all_without_filters():
 
 
 def test_delete_memory():
-    data = {"user_id": 3, "content": "d", "topic": "t", "tags": []}
-    resp = client.post("/memory/add", json=data)
+    user_id, token = _auth()
+    data = {"user_id": user_id, "content": "d", "topic": "t", "tags": []}
+    resp = client.post(
+        "/memory/add",
+        json=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
     memory_id = resp.json()["memory"]["id"]
 
-    resp = client.delete(f"/memory/delete/{memory_id}", params={"user_id": 3})
+    resp = client.delete(
+        f"/memory/delete/{memory_id}",
+        params={"user_id": user_id},
+        headers={"Authorization": f"Bearer {token}"},
+    )
     assert resp.status_code == 200
 
 
 def test_delete_memory_unauthorized():
-    data = {"user_id": 4, "content": "e", "topic": "t", "tags": []}
-    resp = client.post("/memory/add", json=data)
+    user_id, token = _auth()
+    data = {"user_id": user_id, "content": "e", "topic": "t", "tags": []}
+    resp = client.post(
+        "/memory/add",
+        json=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
     memory_id = resp.json()["memory"]["id"]
 
-    resp = client.delete(f"/memory/delete/{memory_id}", params={"user_id": 5})
+    other_id, other_token = _auth()
+    resp = client.delete(
+        f"/memory/delete/{memory_id}",
+        params={"user_id": user_id},
+        headers={"Authorization": f"Bearer {other_token}"},
+    )
     assert resp.status_code == 403

--- a/scoutos-frontend/src/components/AuthForm.test.tsx
+++ b/scoutos-frontend/src/components/AuthForm.test.tsx
@@ -34,13 +34,15 @@ describe('AuthForm', () => {
 
     fireEvent.change(screen.getAllByPlaceholderText('Username')[0], { target: { value: 'bob' } })
     fireEvent.change(screen.getAllByPlaceholderText('Password')[0], { target: { value: 'pw' } })
-    const loginButtons = screen.getAllByRole('button', { name: /login/i })
-    loginButtons.forEach(btn => fireEvent.click(btn))
+    fireEvent.click(screen.getAllByRole('button', { name: /login/i })[0])
 
     await waitFor(() => {
-      expect(setUser).toHaveBeenCalledWith({ id: 1, username: 'bob', token: 't' })
+      expect(fetchMock).toHaveBeenCalled()
     })
-    vi.restoreAllMocks()
+    await waitFor(() => {
+      expect(setUser).toHaveBeenCalled()
+    })
+    expect(setUser).toHaveBeenCalledWith({ id: 1, username: 'bob', token: 'abc' })
   })
 
   it('registers then logs in', async () => {
@@ -62,6 +64,9 @@ describe('AuthForm', () => {
     await waitFor(() => {
       expect(setUser).toHaveBeenCalledWith({ id: 2, username: 'alice', token: 'x' })
     })
-    vi.restoreAllMocks()
+    await waitFor(() => {
+      expect(setUser).toHaveBeenCalled()
+    })
+    expect(setUser).toHaveBeenCalledWith({ id: 1, username: 'bob', token: 'abc' })
   })
 })

--- a/scoutos-frontend/src/components/AuthForm.tsx
+++ b/scoutos-frontend/src/components/AuthForm.tsx
@@ -51,7 +51,7 @@ export default function AuthForm() {
         data = await loginRes.json();
       }
 
-      setUser({ id: data.id, username, token: data.token });
+      setUser({ id: data.id, username, token: data.token, token: data.token });
       setUsername('');
       setPassword('');
     } catch (err) {

--- a/scoutos-frontend/src/components/ChatInterface.tsx
+++ b/scoutos-frontend/src/components/ChatInterface.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useUser } from "../hooks/useUser";
+import LogoutButton from "./LogoutButton";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
 
@@ -70,6 +71,9 @@ export default function ChatInterface() {
 
   return (
     <div className="w-full max-w-xl mx-auto my-8 bg-white rounded-2xl shadow-lg p-4">
+      <div className="flex justify-end mb-2">
+        <LogoutButton />
+      </div>
       <div className="mb-4 h-80 overflow-y-auto">
         {messages.map((msg, i) => (
           <div key={i} className={msg.sender === 'user' ? 'text-right' : 'text-left'}>

--- a/scoutos-frontend/src/components/LogoutButton.test.tsx
+++ b/scoutos-frontend/src/components/LogoutButton.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import LogoutButton from './LogoutButton'
+import { UserContext, type User } from '../context/UserContext'
+
+function renderWithProvider(setUser: (u: User | null) => void) {
+  return render(
+    <UserContext.Provider value={{ user: { id: 1, username: 'bob', token: 'abc' }, setUser }}>
+      <LogoutButton />
+    </UserContext.Provider>
+  )
+}
+
+describe('LogoutButton', () => {
+  it('calls setUser(null) on click', () => {
+    const setUser = vi.fn()
+    const { getByRole } = renderWithProvider(setUser)
+    fireEvent.click(getByRole('button', { name: /logout/i }))
+    expect(setUser).toHaveBeenCalledWith(null)
+  })
+})

--- a/scoutos-frontend/src/components/LogoutButton.tsx
+++ b/scoutos-frontend/src/components/LogoutButton.tsx
@@ -1,0 +1,13 @@
+import { useUser } from '../hooks/useUser';
+
+export default function LogoutButton() {
+  const { setUser } = useUser();
+  return (
+    <button
+      onClick={() => setUser(null)}
+      className="text-sm text-red-600 underline"
+    >
+      Logout
+    </button>
+  );
+}


### PR DESCRIPTION
* Update user endpoint docs (#233)

docs: update user endpoint and auth info

* Add auth validation for memory and agent routes (#232)

Add auth checks for memory and agent routes

* Remove duplicate test definition (#235)

Remove duplicate merge memory test

* Add logout and token handling (#236)

Add token storage and logout button

* Expose OpenAI API key via compose (#239)

Add OPENAI_API_KEY config

---------