### PR TITLE
Ensure token stored in user state

### DIFF
--- a/scoutos-frontend/src/context/UserContext.tsx
+++ b/scoutos-frontend/src/context/UserContext.tsx
@@ -3,7 +3,7 @@ import { createContext, useState, type ReactNode } from 'react';
 export interface User {
   id: number;
   username: string;
-  token: string;
+  token?: string;
 }
 
 interface UserContextType {


### PR DESCRIPTION
## Summary
- allow `User.token` to be optional so null state works
- confirm login stores the token in AuthForm

## Testing
- `pnpm exec vitest run`
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68733483e25483228bc8332b4d56c0b9