### PR TITLE
Add AI helpers to MemoryManager

### DIFF
--- a/scoutos-frontend/src/App.tsx
+++ b/scoutos-frontend/src/App.tsx
@@ -2,6 +2,7 @@ import ChatInterface from './components/ChatInterface';
 import AuthForm from './components/AuthForm';
 import { UserProvider } from './context/UserContext';
 import { useUser } from './hooks/useUser';
+import { Toaster } from 'react-hot-toast';
 import './index.css';
 
 function AppContent() {
@@ -17,6 +18,7 @@ export default function App() {
   return (
     <UserProvider>
       <AppContent />
+      <Toaster position="top-right" />
     </UserProvider>
   );
 }

--- a/scoutos-frontend/src/components/MemoryManager.test.tsx
+++ b/scoutos-frontend/src/components/MemoryManager.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import MemoryManager from './MemoryManager'
+import { UserContext, type User } from '../context/UserContext'
+import type { Mock } from 'vitest'
+
+function renderWithUser(fetchMock: Mock) {
+  const user: User = { id: 1, username: 'bob', token: 'tok' }
+  vi.stubGlobal('fetch', fetchMock)
+  return render(
+    <UserContext.Provider value={{ user, setUser: vi.fn() }}>
+      <MemoryManager />
+    </UserContext.Provider>
+  )
+}
+
+describe('MemoryManager API calls', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls /ai/tags after adding memory', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) }) // list
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ memory: { id: 1, user_id: 1, content: 'c', topic: 't', tags: [] } }) }) // add
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ tags: ['x'] }) }) // tags
+
+    const { getByPlaceholderText, getByText } = renderWithUser(fetchMock)
+
+    fireEvent.change(getByPlaceholderText('Content'), { target: { value: 'c' } })
+    fireEvent.change(getByPlaceholderText('Topic'), { target: { value: 't' } })
+    fireEvent.change(getByPlaceholderText('Tags comma separated'), { target: { value: '' } })
+    fireEvent.click(getByText('Add Memory'))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/ai/tags'), expect.any(Object))
+    })
+  })
+
+  it('requests summary and merge advice', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) }) // list
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+
+    const { getAllByText } = renderWithUser(fetchMock)
+
+    fireEvent.click(getAllByText('Get Summary')[0])
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/ai/summary'), expect.any(Object))
+    })
+
+    fireEvent.click(getAllByText('Merge Advice')[0])
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/ai/merge'), expect.any(Object))
+    })
+  })
+})

--- a/scoutos-frontend/src/components/MemoryManager.tsx
+++ b/scoutos-frontend/src/components/MemoryManager.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { toast } from 'react-hot-toast'
 import { useUser } from "../hooks/useUser";
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
@@ -17,6 +18,7 @@ export default function MemoryManager() {
   const [content, setContent] = useState("");
   const [topic, setTopic] = useState("");
   const [tags, setTags] = useState("");
+  const [suggestedTags, setSuggestedTags] = useState<string[]>([]);
   const [searchTopic, setSearchTopic] = useState("");
   const [searchTag, setSearchTag] = useState("");
   const { user } = useUser();
@@ -33,6 +35,25 @@ export default function MemoryManager() {
   }, [user]);
 
   useEffect(() => { loadMemories(); }, [loadMemories]);
+
+  async function fetchTagsFor(contentText: string) {
+    if (!contentText) return;
+    const res = await fetch(`${API_URL}/ai/tags`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(user?.token ? { Authorization: `Bearer ${user.token}` } : {}),
+      },
+      body: JSON.stringify({ content: contentText }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (Array.isArray(data.tags)) {
+        setSuggestedTags(data.tags);
+        toast.success(`Suggested tags: ${data.tags.join(', ')}`);
+      }
+    }
+  }
 
   async function addMemory() {
     if (!user) return;
@@ -55,6 +76,7 @@ export default function MemoryManager() {
       setContent("");
       setTopic("");
       setTags("");
+      fetchTagsFor(content);
     }
   }
 
@@ -81,6 +103,41 @@ export default function MemoryManager() {
     setMemories(memories.filter(m => m.id !== id));
   }
 
+  async function requestSummary() {
+    if (!user) return;
+    const res = await fetch(`${API_URL}/ai/summary`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(user.token ? { Authorization: `Bearer ${user.token}` } : {}),
+      },
+      body: JSON.stringify({ user_id: user.id }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      toast.success(data.summary || 'Summary requested');
+    }
+  }
+
+  async function requestMergeAdvice() {
+    if (!user) return;
+    const res = await fetch(`${API_URL}/ai/merge`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(user.token ? { Authorization: `Bearer ${user.token}` } : {}),
+      },
+      body: JSON.stringify({
+        user_id: user.id,
+        memory_ids: memories.map(m => m.id),
+      }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      toast.success(data.message || 'Merge advice requested');
+    }
+  }
+
   return (
     <div className="bg-white rounded-xl shadow p-4">
       <h2 className="text-xl font-semibold mb-2">Memories</h2>
@@ -89,12 +146,20 @@ export default function MemoryManager() {
         <input className="border p-2 rounded" placeholder="Topic" value={topic} onChange={e => setTopic(e.target.value)} />
         <input className="border p-2 rounded" placeholder="Tags comma separated" value={tags} onChange={e => setTags(e.target.value)} />
         <button className="bg-blue-600 text-white rounded p-2" onClick={addMemory}>Add Memory</button>
+        {suggestedTags.length > 0 && (
+          <div className="text-sm text-gray-600">Suggested tags: {suggestedTags.join(', ')}</div>
+        )}
       </div>
 
       <div className="flex gap-2 mb-4">
         <input className="border p-2 rounded" placeholder="Search topic" value={searchTopic} onChange={e => setSearchTopic(e.target.value)} />
         <input className="border p-2 rounded" placeholder="Search tag" value={searchTag} onChange={e => setSearchTag(e.target.value)} />
         <button className="bg-green-600 text-white rounded p-2" onClick={search}>Search</button>
+      </div>
+
+      <div className="flex gap-2 mb-4">
+        <button className="bg-purple-600 text-white rounded p-2" onClick={requestSummary}>Get Summary</button>
+        <button className="bg-purple-600 text-white rounded p-2" onClick={requestMergeAdvice}>Merge Advice</button>
       </div>
 
       <ul className="space-y-2">


### PR DESCRIPTION
## Summary
- show toast notifications via Toaster
- request tag suggestions after adding a memory
- add controls for memory summary and merge advice
- include user token on new API calls
- test that new endpoints are triggered

## Testing
- `pnpm exec vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687334861b0083228a02b019fe0c1a10