### PR TITLE
Add APP_ENCRYPTION_KEY env variable docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ POSTGRES_PASSWORD=password
 POSTGRES_DB=scoutos
 DATABASE_URL=postgresql://postgres:password@db:5432/scoutos
 OPENAI_API_KEY=
+# APP_ENCRYPTION_KEY= # required for encrypting Memory.content

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
-The service reads `DATABASE_URL` to connect to PostgreSQL (tests override this with SQLite). See [`scoutos-backend/README.md`](scoutos-backend/README.md) for more details on environment variables and endpoints.
+The service reads `DATABASE_URL` to connect to PostgreSQL (tests override this with SQLite). Set `APP_ENCRYPTION_KEY` to a random string so `Memory.content` can be encrypted. See [`scoutos-backend/README.md`](scoutos-backend/README.md) for more details on environment variables and endpoints.
 
 Run the backend unit tests from the same directory:
 


### PR DESCRIPTION
## Summary
- update `.env.example` with a commented APP_ENCRYPTION_KEY line
- document the new variable in the backend setup section of the README

## Testing
- `pytest -q` *(fails: SyntaxError in app/routes/ai.py)*

------
https://chatgpt.com/codex/tasks/task_e_68733a84dc7883229a06fcd3735ee47a