### PR TITLE
Fix MemoryManager delete API query

### DIFF
--- a/scoutos-frontend/src/components/MemoryManager.tsx
+++ b/scoutos-frontend/src/components/MemoryManager.tsx
@@ -96,7 +96,7 @@ export default function MemoryManager() {
   }
 
   async function deleteMemory(id: number) {
-    await fetch(`${API_URL}/memory/delete/${id}`, {
+    await fetch(`${API_URL}/memory/delete/${id}?user_id=${user.id}`, {
       method: 'DELETE',
       headers: user?.token ? { Authorization: `Bearer ${user.token}` } : {},
     });


### PR DESCRIPTION
## Summary
- update MemoryManager.deleteMemory to include the user id query parameter
- keep local memory removal

## Testing
- `npm run lint`
- `pnpm test --run` *(fails: AuthForm tests)*

------
https://chatgpt.com/codex/tasks/task_e_68733a840cc88322b9acdaad625f090e