### PR TITLE
Fix UserProvider import and auth tests

### DIFF
--- a/scoutos-frontend/src/App.tsx
+++ b/scoutos-frontend/src/App.tsx
@@ -2,6 +2,7 @@ import ChatInterface from './components/ChatInterface';
 import AuthForm from './components/AuthForm';
 import { useUser } from './hooks/useUser';
 import { Toaster } from 'react-hot-toast';
+import { UserProvider } from '../context/UserContext';
 import './index.css';
 
 function AppContent() {

--- a/scoutos-frontend/src/components/AuthForm.test.tsx
+++ b/scoutos-frontend/src/components/AuthForm.test.tsx
@@ -42,7 +42,7 @@ describe('AuthForm', () => {
     await waitFor(() => {
       expect(setUser).toHaveBeenCalled()
     })
-    expect(setUser).toHaveBeenCalledWith({ id: 1, username: 'bob', token: 'abc' })
+    expect(setUser).toHaveBeenCalledWith({ id: 1, username: 'bob', token: 't' })
   })
 
   it('registers then logs in', async () => {
@@ -64,9 +64,5 @@ describe('AuthForm', () => {
     await waitFor(() => {
       expect(setUser).toHaveBeenCalledWith({ id: 2, username: 'alice', token: 'x' })
     })
-    await waitFor(() => {
-      expect(setUser).toHaveBeenCalled()
-    })
-    expect(setUser).toHaveBeenCalledWith({ id: 1, username: 'bob', token: 'abc' })
   })
 })

--- a/scoutos-frontend/src/components/AuthForm.tsx
+++ b/scoutos-frontend/src/components/AuthForm.tsx
@@ -51,7 +51,7 @@ export default function AuthForm() {
         data = await loginRes.json();
       }
 
-      setUser({ id: data.id, username, token: data.token, token: data.token });
+      setUser({ id: data.id, username, token: data.token });
       setUsername('');
       setPassword('');
     } catch (err) {


### PR DESCRIPTION
## Summary
- add missing `UserProvider` import
- remove duplicate `token` property
- update auth form tests for correct tokens

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68733c64141c832286f3cbfdef87ecc9