### PR TITLE
Add encryption key docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,7 @@ POSTGRES_PASSWORD=password
 POSTGRES_DB=scoutos
 DATABASE_URL=postgresql://postgres:password@db:5432/scoutos
 OPENAI_API_KEY=
-# APP_ENCRYPTION_KEY= # required for encrypting Memory.content
+# Random 32-byte key used for Fernet encryption
+FERNET_KEY=
+# Key used by app.utils.encryption to secure PHI fields
+APP_ENCRYPTION_KEY=

--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 ## Setup
 
-`docker-compose.yml` expects the database password in `POSTGRES_PASSWORD` and
-an OpenAI API key in `OPENAI_API_KEY`. Set these variables before starting the stack:
+`docker-compose.yml` expects the database password in `POSTGRES_PASSWORD`, an
+OpenAI API key in `OPENAI_API_KEY`, and two encryption keys: `FERNET_KEY` and
+`APP_ENCRYPTION_KEY`. Generate each key with `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
+and set the variables before starting the stack:
 
 ```bash
 export POSTGRES_PASSWORD=yourpassword
 export OPENAI_API_KEY=sk-...
+export FERNET_KEY=$(python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
+export APP_ENCRYPTION_KEY=$(python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
 docker-compose up
 ```
 
@@ -26,7 +30,7 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
-The service reads `DATABASE_URL` to connect to PostgreSQL (tests override this with SQLite). Set `APP_ENCRYPTION_KEY` to a random string so `Memory.content` can be encrypted. See [`scoutos-backend/README.md`](scoutos-backend/README.md) for more details on environment variables and endpoints.
+The service reads `DATABASE_URL` to connect to PostgreSQL (tests override this with SQLite). Set both `FERNET_KEY` and `APP_ENCRYPTION_KEY` to random strings so `Memory.content` can be encrypted. See [`scoutos-backend/README.md`](scoutos-backend/README.md) for more details on environment variables and endpoints.
 
 Run the backend unit tests from the same directory:
 

--- a/scoutos-backend/README.md
+++ b/scoutos-backend/README.md
@@ -27,11 +27,17 @@ demo endpoints can call the OpenAI API.
 
 ### Environment variables
 
-Database credentials and your OpenAI key are provided via a `.env` file. From the repository root,
+Database credentials, API keys and encryption keys are provided via a `.env` file. From the repository root,
 copy `.env.example` to `.env` and adjust the values as needed:
 
 ```bash
 cp .env.example .env
+```
+
+Generate random base64 values for `FERNET_KEY` and `APP_ENCRYPTION_KEY` with:
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ```
 
 Docker Compose reads this file automatically when launching the services.


### PR DESCRIPTION
## Summary
- document APP_ENCRYPTION_KEY and FERNET_KEY
- add examples of generating keys
- update `.env.example` to include the new vars

## Testing
- `pytest -q`
- `pnpm test` *(fails: AuthForm.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6873414d293c83228a66f0f0a28c2c01