### PR TITLE
Update AuthForm tests for correct tokens

### DIFF
--- a/scoutos-frontend/src/components/AuthForm.test.tsx
+++ b/scoutos-frontend/src/components/AuthForm.test.tsx
@@ -27,7 +27,7 @@ describe('AuthForm', () => {
 
   it('submits login data', async () => {
     const setUser = vi.fn()
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ id: 1, token: 'abc' }) })
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ id: 1, token: 't' }) })
     vi.stubGlobal('fetch', fetchMock)
 
     renderWithProvider(setUser)
@@ -50,7 +50,7 @@ describe('AuthForm', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: 2 }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: 2, token: 'abc' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: 2, token: 'x' }) })
     vi.stubGlobal('fetch', fetchMock)
 
     renderWithProvider(setUser)
@@ -62,12 +62,7 @@ describe('AuthForm', () => {
     regButtons.forEach(btn => fireEvent.click(btn))
 
     await waitFor(() => {
-      expect(setUser).toHaveBeenCalledWith({ id: 2, username: 'alice', token: 'abc' })
+      expect(setUser).toHaveBeenCalledWith({ id: 2, username: 'alice', token: 'x' })
     })
-    await waitFor(() => {
-      expect(setUser).toHaveBeenCalled()
-    })
-    expect(setUser).toHaveBeenCalledWith({ id: 1, username: 'bob', token: 'abc' })
-    expect(setUser).toHaveBeenCalledWith({ id: 2, username: 'alice', token: 'abc' })
   })
 })


### PR DESCRIPTION
## Summary
- fix login token mocked response to return `'t'`
- fix register/login token mocked response to return `'x'`
- verify `setUser` arguments match the mocked tokens

## Testing
- `npm run lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6873414c488483228f28ce586168641a