### PR TITLE
Implement AI tags and merge endpoints

### DIFF
--- a/scoutos-backend/app/routes/ai.py
+++ b/scoutos-backend/app/routes/ai.py
@@ -1,12 +1,24 @@
 """Routes related to AI interactions using the OpenAI API."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from openai import AsyncOpenAI
 import os
-from typing import Dict, List
+from typing import Dict, Generator, List
+from sqlalchemy.orm import Session
+
+from app.db import SessionLocal
+from app.services.memory_service import MemoryService
 
 router = APIRouter()
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 
 class AIRequest(BaseModel):
@@ -53,14 +65,14 @@ async def ai_chat(req: AIRequest) -> Dict[str, str]:
 
 
 class TagRequest(BaseModel):
-    content: str
+    text: str
 
 
 @router.post("/tags")
 async def ai_tags(req: TagRequest) -> Dict[str, List[str]]:
     prompt = (
         "Suggest 3 to 5 short single-word tags for the following text. "
-        "Return only a comma separated list of the tags.\n" + req.content
+        "Return only a comma separated list of the tags.\n" + req.text
     )
     answer = await _ask_openai(prompt)
     tags = [t.strip() for t in answer.split(";") if t.strip()]
@@ -69,19 +81,31 @@ async def ai_tags(req: TagRequest) -> Dict[str, List[str]]:
     return {"tags": tags}
 
 
-class MergeAdviceRequest(BaseModel):
-    memory_a: str
-    memory_b: str
+class MergeRequest(BaseModel):
+    memory_ids: List[int]
 
 
 @router.post("/merge")
-async def ai_merge(req: MergeAdviceRequest) -> Dict[str, str]:
+async def ai_merge(
+    req: MergeRequest, db: Session = Depends(get_db)
+) -> Dict[str, str]:
+    service = MemoryService(db)
+    memories: List[str] = []
+    for mem_id in req.memory_ids:
+        mem = service.get_memory(mem_id)
+        if not mem:
+            raise HTTPException(status_code=404, detail="Memory not found")
+        memories.append(mem.content)
+
+    joined = "\n".join(
+        f"Memory {i + 1}:\n{content}" for i, content in enumerate(memories)
+    )
     prompt = (
-        "Provide guidance on how to merge the following two memory entries and "
-        "explain the reasoning:\nMemory A:\n" + req.memory_a + "\nMemory B:\n" + req.memory_b
+        "Should these memories be merged? Reply 'Yes' or 'No' and include a brief "
+        "reason.\n" + joined
     )
     answer = await _ask_openai(prompt)
-    return {"response": answer}
+    return {"verdict": answer}
 
 
 class SummaryRequest(BaseModel):

--- a/scoutos-backend/tests/test_ai.py
+++ b/scoutos-backend/tests/test_ai.py
@@ -44,7 +44,7 @@ def test_ai_chat_returns_mocked_text(monkeypatch):
 
 def test_ai_tags_missing_api_key(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    resp = client.post("/ai/tags", json={"content": "memo"})
+    resp = client.post("/ai/tags", json={"text": "memo"})
     assert resp.status_code == 500
     assert "OPENAI_API_KEY" in resp.json()["detail"]
 
@@ -69,14 +69,24 @@ def test_ai_tags_returns_mocked_tags(monkeypatch):
 
     monkeypatch.setattr(ai_module, "AsyncOpenAI", lambda **_: fake_client)
 
-    resp = client.post("/ai/tags", json={"content": "text"})
+    resp = client.post("/ai/tags", json={"text": "text"})
     assert resp.status_code == 200
     assert resp.json() == {"tags": ["x", "y"]}
 
 
 def test_ai_merge_missing_api_key(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    resp = client.post("/ai/merge", json={"memory_a": "a", "memory_b": "b"})
+    from types import SimpleNamespace
+    class FakeService:
+        def __init__(self, _db):
+            pass
+
+        def get_memory(self, mid):
+            return SimpleNamespace(content=f"m{mid}")
+
+    monkeypatch.setattr(ai_module, "MemoryService", FakeService)
+
+    resp = client.post("/ai/merge", json={"memory_ids": [1, 2]})
     assert resp.status_code == 500
     assert "OPENAI_API_KEY" in resp.json()["detail"]
 
@@ -99,14 +109,20 @@ def test_ai_merge_returns_mocked_text(monkeypatch):
         )
     )
 
+    class FakeService:
+        def __init__(self, _db):
+            pass
+
+        def get_memory(self, mid):
+            return SimpleNamespace(content=f"mem{mid}")
+
+    monkeypatch.setattr(ai_module, "MemoryService", FakeService)
+
     monkeypatch.setattr(ai_module, "AsyncOpenAI", lambda **_: fake_client)
 
-    resp = client.post(
-        "/ai/merge",
-        json={"memory_a": "one", "memory_b": "two"},
-    )
+    resp = client.post("/ai/merge", json={"memory_ids": [1, 2]})
     assert resp.status_code == 200
-    assert resp.json() == {"response": "merge"}
+    assert resp.json() == {"verdict": "merge"}
 
 
 def test_ai_summary_missing_api_key(monkeypatch):


### PR DESCRIPTION
## Summary
- update `/ai/tags` to accept text and return list of tags
- add DB access to `/ai/merge` and fetch memories by ID
- return verdict from OpenAI on whether to merge
- adapt AI tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687347328088832281d0f9212b195db5