### PR TITLE
Add flexible agent service

### DIFF
--- a/scoutos-backend/app/routes/ai.py
+++ b/scoutos-backend/app/routes/ai.py
@@ -1,10 +1,10 @@
 """Routes related to AI interactions using the OpenAI API."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from pydantic import BaseModel
-from openai import AsyncOpenAI
-import os
 from typing import Dict, List
+
+from app.services.agent_service import AgentService
 
 router = APIRouter()
 
@@ -13,42 +13,10 @@ class AIRequest(BaseModel):
     prompt: str
 
 
-async def _ask_openai(prompt: str, max_tokens: int = 200) -> str:
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise HTTPException(
-            status_code=500,
-            detail="OPENAI_API_KEY environment variable is not set",
-        )
-
-    try:
-        client = AsyncOpenAI(api_key=api_key)
-        completions = client.chat.completions
-        if hasattr(completions, "create"):
-            resp = await completions.create(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "user", "content": prompt}],
-                max_tokens=max_tokens,
-            )
-        else:
-            resp = await completions.acreate(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "user", "content": prompt}],
-                max_tokens=max_tokens,
-            )
-        answer = resp.choices[0].message.content
-    except Exception as exc:
-        raise HTTPException(
-            status_code=503,
-            detail=f"OpenAI request failed: {exc}",
-        )
-
-    return answer
-
-
 @router.post("/chat")
 async def ai_chat(req: AIRequest) -> Dict[str, str]:
-    answer = await _ask_openai(req.prompt)
+    service = AgentService()
+    answer = await service.chat(req.prompt)
     return {"response": answer}
 
 
@@ -58,14 +26,8 @@ class TagRequest(BaseModel):
 
 @router.post("/tags")
 async def ai_tags(req: TagRequest) -> Dict[str, List[str]]:
-    prompt = (
-        "Suggest 3 to 5 short single-word tags for the following text. "
-        "Return only a comma separated list of the tags.\n" + req.content
-    )
-    answer = await _ask_openai(prompt)
-    tags = [t.strip() for t in answer.split(";") if t.strip()]
-    if len(tags) == 1:
-        tags = [t.strip() for t in answer.split(",") if t.strip()]
+    service = AgentService()
+    tags = await service.generate_tags(req.content)
     return {"tags": tags}
 
 
@@ -76,11 +38,8 @@ class MergeAdviceRequest(BaseModel):
 
 @router.post("/merge")
 async def ai_merge(req: MergeAdviceRequest) -> Dict[str, str]:
-    prompt = (
-        "Provide guidance on how to merge the following two memory entries and "
-        "explain the reasoning:\nMemory A:\n" + req.memory_a + "\nMemory B:\n" + req.memory_b
-    )
-    answer = await _ask_openai(prompt)
+    service = AgentService()
+    answer = await service.merge_advice(req.memory_a, req.memory_b)
     return {"response": answer}
 
 
@@ -90,7 +49,8 @@ class SummaryRequest(BaseModel):
 
 @router.post("/summary")
 async def ai_summary(req: SummaryRequest) -> Dict[str, str]:
+    service = AgentService()
     prompt = "Summarize the following text in a short paragraph:\n" + req.content
-    answer = await _ask_openai(prompt, max_tokens=100)
+    answer = await service.chat(prompt, max_tokens=100)
     return {"summary": answer}
 

--- a/scoutos-backend/app/services/agent_service.py
+++ b/scoutos-backend/app/services/agent_service.py
@@ -1,5 +1,118 @@
-# Placeholder for agent-related business logic
+"""Agent service and backends for chat and tagging."""
+
+from __future__ import annotations
+
+import os
+from typing import Protocol, List
+
+from fastapi import HTTPException
+from openai import AsyncOpenAI
+
+
+class AgentBackend(Protocol):
+    """Interface for agent model backends."""
+
+    async def chat(self, prompt: str, max_tokens: int = 200) -> str:
+        """Return a chat completion."""
+
+    async def generate_tags(self, content: str) -> List[str]:
+        """Suggest tags for ``content``."""
+
+    async def merge_advice(self, memory_a: str, memory_b: str) -> str:
+        """Return merge guidance for two memories."""
+
+
+class OpenAIBackend:
+    """Backend that calls the OpenAI API."""
+
+    def __init__(self) -> None:
+        self.api_key = os.getenv("OPENAI_API_KEY")
+
+    async def _ask(self, prompt: str, max_tokens: int = 200) -> str:
+        if not self.api_key:
+            raise HTTPException(
+                status_code=500,
+                detail="OPENAI_API_KEY environment variable is not set",
+            )
+        try:
+            client = AsyncOpenAI(api_key=self.api_key)
+            completions = client.chat.completions
+            if hasattr(completions, "create"):
+                resp = await completions.create(
+                    model="gpt-3.5-turbo",
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=max_tokens,
+                )
+            else:
+                resp = await completions.acreate(
+                    model="gpt-3.5-turbo",
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=max_tokens,
+                )
+            return resp.choices[0].message.content
+        except Exception as exc:  # pragma: no cover - network errors
+            raise HTTPException(
+                status_code=503,
+                detail=f"OpenAI request failed: {exc}",
+            )
+
+    async def chat(self, prompt: str, max_tokens: int = 200) -> str:
+        return await self._ask(prompt, max_tokens=max_tokens)
+
+    async def generate_tags(self, content: str) -> List[str]:
+        prompt = (
+            "Suggest 3 to 5 short single-word tags for the following text. "
+            "Return only a comma separated list of the tags.\n" + content
+        )
+        answer = await self._ask(prompt)
+        tags = [t.strip() for t in answer.split(";") if t.strip()]
+        if len(tags) == 1:
+            tags = [t.strip() for t in answer.split(",") if t.strip()]
+        return tags
+
+    async def merge_advice(self, memory_a: str, memory_b: str) -> str:
+        prompt = (
+            "Provide guidance on how to merge the following two memory entries "
+            "and explain the reasoning:\nMemory A:\n" + memory_a + "\nMemory B:\n" + memory_b
+        )
+        return await self._ask(prompt)
+
+
+class LocalBackend:
+    """Very small stub backend for local testing."""
+
+    async def chat(self, prompt: str, max_tokens: int = 200) -> str:  # noqa: ARG002
+        return "Local model response"
+
+    async def generate_tags(self, content: str) -> List[str]:  # noqa: ARG002
+        return []
+
+    async def merge_advice(self, memory_a: str, memory_b: str) -> str:  # noqa: ARG002
+        return "Local merge advice"
+
 
 class AgentService:
-    def get_status(self):
-        return {"status": "Agent module placeholder"}
+    """Service facade selecting the desired backend."""
+
+    def __init__(self, backend: AgentBackend | None = None) -> None:
+        if backend:
+            self.backend = backend
+        else:
+            kind = os.getenv("AGENT_BACKEND", "openai").lower()
+            if kind == "local":
+                self.backend = LocalBackend()
+            else:
+                self.backend = OpenAIBackend()
+
+    async def chat(self, prompt: str, max_tokens: int = 200) -> str:
+        return await self.backend.chat(prompt, max_tokens=max_tokens)
+
+    async def generate_tags(self, content: str) -> List[str]:
+        return await self.backend.generate_tags(content)
+
+    async def merge_advice(self, memory_a: str, memory_b: str) -> str:
+        return await self.backend.merge_advice(memory_a, memory_b)
+
+    def get_status(self) -> dict[str, str]:
+        return {"backend": self.backend.__class__.__name__}
+

--- a/scoutos-backend/tests/test_ai.py
+++ b/scoutos-backend/tests/test_ai.py
@@ -1,7 +1,8 @@
 from fastapi.testclient import TestClient
 import os
 import sys
-from app.routes import ai as ai_module
+
+from app.services import agent_service
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from app.main import app  # noqa: E402
@@ -35,7 +36,7 @@ def test_ai_chat_returns_mocked_text(monkeypatch):
         )
     )
 
-    monkeypatch.setattr(ai_module, "AsyncOpenAI", lambda **_: fake_client)
+    monkeypatch.setattr(agent_service, "AsyncOpenAI", lambda **_: fake_client)
 
     resp = client.post("/ai/chat", json={"prompt": "hi"})
     assert resp.status_code == 200
@@ -67,7 +68,7 @@ def test_ai_tags_returns_mocked_tags(monkeypatch):
         )
     )
 
-    monkeypatch.setattr(ai_module, "AsyncOpenAI", lambda **_: fake_client)
+    monkeypatch.setattr(agent_service, "AsyncOpenAI", lambda **_: fake_client)
 
     resp = client.post("/ai/tags", json={"content": "text"})
     assert resp.status_code == 200
@@ -99,7 +100,7 @@ def test_ai_merge_returns_mocked_text(monkeypatch):
         )
     )
 
-    monkeypatch.setattr(ai_module, "AsyncOpenAI", lambda **_: fake_client)
+    monkeypatch.setattr(agent_service, "AsyncOpenAI", lambda **_: fake_client)
 
     resp = client.post(
         "/ai/merge",
@@ -134,7 +135,7 @@ def test_ai_summary_returns_mocked_text(monkeypatch):
         )
     )
 
-    monkeypatch.setattr(ai_module, "AsyncOpenAI", lambda **_: fake_client)
+    monkeypatch.setattr(agent_service, "AsyncOpenAI", lambda **_: fake_client)
 
     resp = client.post("/ai/summary", json={"content": "the text"})
     assert resp.status_code == 200
@@ -160,7 +161,7 @@ def test_ai_chat_async_returns_mocked_text(monkeypatch):
         )
     )
 
-    monkeypatch.setattr(ai_module, "AsyncOpenAI", lambda **_: fake_client)
+    monkeypatch.setattr(agent_service, "AsyncOpenAI", lambda **_: fake_client)
 
     resp = client.post("/ai/chat", json={"prompt": "hello"})
     assert resp.status_code == 200
@@ -182,7 +183,7 @@ def test_ai_chat_handles_openai_error(monkeypatch):
         )
     )
 
-    monkeypatch.setattr(ai_module, "AsyncOpenAI", lambda **_: fake_client)
+    monkeypatch.setattr(agent_service, "AsyncOpenAI", lambda **_: fake_client)
 
     resp = client.post("/ai/chat", json={"prompt": "boom"})
     assert resp.status_code == 503


### PR DESCRIPTION
## Summary
- implement `AgentService` with OpenAI and local backends
- route AI endpoints through `AgentService`
- adjust tests to patch `AsyncOpenAI` in the new service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873473f761c83228ada43422ca1f2b1