### PR TITLE
Add staging/production env examples

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,9 @@
+POSTGRES_USER=scoutos
+POSTGRES_PASSWORD=prodpass
+POSTGRES_DB=scoutos_prod
+DATABASE_URL=postgresql://scoutos:prodpass@db:5432/scoutos_prod
+OPENAI_API_KEY=
+# Random 32-byte key used for Fernet encryption
+FERNET_KEY=
+# Key used by app.utils.encryption to secure PHI fields
+APP_ENCRYPTION_KEY=

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,9 @@
+POSTGRES_USER=scoutos
+POSTGRES_PASSWORD=stagingpass
+POSTGRES_DB=scoutos_staging
+DATABASE_URL=postgresql://scoutos:stagingpass@db:5432/scoutos_staging
+OPENAI_API_KEY=
+# Random 32-byte key used for Fernet encryption
+FERNET_KEY=
+# Key used by app.utils.encryption to secure PHI fields
+APP_ENCRYPTION_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ node_modules/
 dist/
 .env.*
 !.env.example
+!.env.staging.example
+!.env.prod.example
 .DS_Store
 # Ignore SQLite test database
 scoutos-backend/test.db

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ export OPENAI_API_KEY=sk-...
 docker-compose up
 ```
 
+Sample environment files are provided for development, staging, and production.
+Copy the appropriate file to `.env` and pass it to docker-compose:
+
+```bash
+cp .env.staging.example .env  # or .env.prod.example
+docker-compose --env-file .env up
+```
+
 The backend service uses these values when constructing `DATABASE_URL` and when
 calling the OpenAI API for the demo AI endpoints.
 


### PR DESCRIPTION
## Summary
- add `.env.staging.example` and `.env.prod.example`
- allow these example env files in `.gitignore`
- document usage of environment files in README

## Testing
- `pytest -q`
- `pnpm test --silent` *(fails: expected "spy" to be called)*

------
https://chatgpt.com/codex/tasks/task_e_6873474396e483228df22d3f1a053333