### PR TITLE
Fix AI routes and loading state

### DIFF
--- a/scoutos-backend/tests/test_ai.py
+++ b/scoutos-backend/tests/test_ai.py
@@ -6,6 +6,7 @@ from app.services import agent_service
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from app.main import app  # noqa: E402
+from app.routes import ai as ai_module
 
 client = TestClient(app)
 

--- a/scoutos-backend/tests/test_services.py
+++ b/scoutos-backend/tests/test_services.py
@@ -69,8 +69,8 @@ def test_memory_service_crud():
 def test_memory_service_unauthorized_operations():
     db = SessionLocal()
     user_service = UserService(db)
-    user_a = user_service.create_user({"username": "ua", "password": "pw"})
-    user_b = user_service.create_user({"username": "ub", "password": "pw"})
+    user_a = user_service.create_user({"username": f"ua_{uuid.uuid4().hex[:8]}", "password": "pw"})
+    user_b = user_service.create_user({"username": f"ub_{uuid.uuid4().hex[:8]}", "password": "pw"})
 
     mem_service = MemoryService(db)
     mem = mem_service.add_memory({"user_id": user_a.id, "content": "c", "topic": "t", "tags": []})

--- a/scoutos-frontend/src/App.tsx
+++ b/scoutos-frontend/src/App.tsx
@@ -5,7 +5,6 @@ import LogoutButton from './components/LogoutButton';
 import AuthForm from './components/AuthForm';
 import { useUser } from './hooks/useUser';
 import { Toaster } from 'react-hot-toast';
-import { UserProvider } from './context/UserContext';
 import './index.css';
 
 function AppContent() {

--- a/scoutos-frontend/src/components/ChatInterface.tsx
+++ b/scoutos-frontend/src/components/ChatInterface.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react"
 import { toast } from 'react-hot-toast'
 import { useUser } from "../hooks/useUser"
-import LogoutButton from "./LogoutButton"
 import LoadingSpinner from './LoadingSpinner'
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";

--- a/scoutos-frontend/src/components/MemoryManager.tsx
+++ b/scoutos-frontend/src/components/MemoryManager.tsx
@@ -27,6 +27,7 @@ export default function MemoryManager() {
   const [editContent, setEditContent] = useState("");
   const [editTopic, setEditTopic] = useState("");
   const [editTags, setEditTags] = useState("");
+  const [loading, setLoading] = useState(false);
   const { user } = useUser();
 
   const loadMemories = useCallback(async () => {


### PR DESCRIPTION
## Summary
- add missing `loading` state in `MemoryManager`
- clean up unused imports in frontend
- overhaul `/ai` routes
  - add `_ask_openai` helper
  - fix `/tags` and `/merge` endpoints
- update backend tests for AI module import and unique usernames

## Testing
- `npm run lint`
- `pnpm test --run`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68735438a1dc832290883f10deb88a3c