### PR TITLE
Implement content search and dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ docker-compose --env-file .env up
 The backend service uses these values when constructing `DATABASE_URL` and when
 calling the OpenAI API for the demo AI endpoints.
 
+The compose file also builds the React frontend so the full stack runs with a
+single command. Visit `http://localhost:3000` after running `docker-compose up`.
+
 ScoutOSAI is a demo full-stack project that pairs a FastAPI backend with a React + Vite frontend. The application exposes a small API for managing user information and storing short text "memories". The web client provides a minimal chat interface for experimenting with the API.
 
 ## Backend Setup
@@ -68,6 +71,9 @@ Start the development server with:
 ```bash
 pnpm run dev
 ```
+
+The UI includes a dark mode toggle in the navigation bar. Use it to switch
+between light and dark themes.
 
 Lint and run tests with:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,14 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
     depends_on:
       - db
+  frontend:
+    build: ./scoutos-frontend
+    ports:
+      - "3000:3000"
+    environment:
+      - VITE_API_URL=http://backend:8000
+    depends_on:
+      - backend
   db:
     image: postgres:15
     restart: always

--- a/scoutos-backend/README.md
+++ b/scoutos-backend/README.md
@@ -57,7 +57,7 @@ purpose.
 | `POST` | `/memory/add` | Store a memory |
 | `PUT` | `/memory/update/{id}` | Update a memory |
 | `GET` | `/memory/list` | List memories for a user |
-| `GET` | `/memory/search` | Filter by topic/tag |
+| `GET` | `/memory/search` | Filter by topic, tag, or content |
 | `DELETE` | `/memory/delete/{id}` | Delete a memory |
 | `POST` | `/ai/chat` | Chat with OpenAI |
 | `POST` | `/ai/tags` | Suggest tags for text |

--- a/scoutos-backend/app/routes/memory.py
+++ b/scoutos-backend/app/routes/memory.py
@@ -98,6 +98,7 @@ def search_memories(
     user_id: int,
     topic: Optional[str] = None,
     tag: Optional[str] = None,
+    content: Optional[str] = None,
     current_user: Dict[str, Any] = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> List[Dict[str, Any]]:
@@ -105,7 +106,7 @@ def search_memories(
         raise HTTPException(status_code=403, detail="Unauthorized")
 
     service = MemoryService(db)
-    mems = service.search_memories(user_id, topic=topic, tag=tag)
+    mems = service.search_memories(user_id, topic=topic, tag=tag, content=content)
     return [_serialize(m) for m in mems]
 
 

--- a/scoutos-backend/app/services/memory_service.py
+++ b/scoutos-backend/app/services/memory_service.py
@@ -70,15 +70,22 @@ class MemoryService:
         user_id: int,
         topic: str | None = None,
         tag: str | None = None,
+        content: str | None = None,
     ) -> List[Memory]:
-        """Return memories for ``user_id`` optionally filtered by ``topic`` and ``tag``."""
+        """Return memories for ``user_id`` filtered by ``topic``, ``tag`` or ``content``."""
 
         query = self.db.query(Memory).filter(Memory.user_id == user_id)
         if topic is not None:
             query = query.filter(Memory.topic == topic)
         if tag is not None:
             query = query.filter(Memory.tags.contains([tag]))
-        return [self._decrypt_mem(m) for m in query.all()]
+
+        mems = [self._decrypt_mem(m) for m in query.all()]
+
+        if content is not None:
+            lowered = content.lower()
+            mems = [m for m in mems if lowered in m.content.lower()]
+        return mems
 
     def update_memory(self, memory_id: int, user_id: int, updates: dict) -> Memory | None:
         """Update an existing ``Memory`` with provided values if owned by ``user_id``."""

--- a/scoutos-backend/tests/test_memory.py
+++ b/scoutos-backend/tests/test_memory.py
@@ -153,6 +153,28 @@ def test_search_memory_filters_by_topic_and_tag():
     assert [m["content"] for m in both.json()] == ["b"]
 
 
+def test_search_memory_filters_by_content():
+    user_id, token = _auth()
+
+    mems = [
+        {"content": "find me", "topic": "alpha", "tags": []},
+        {"content": "other", "topic": "alpha", "tags": []},
+    ]
+    for m in mems:
+        client.post(
+            "/memory/add",
+            json={"user_id": user_id, **m},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    by_content = client.get(
+        "/memory/search",
+        params={"user_id": user_id, "content": "find"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert [m["content"] for m in by_content.json()] == ["find me"]
+
+
 def test_search_memory_returns_all_without_filters():
     user_id, token = _auth()
 

--- a/scoutos-frontend/Dockerfile
+++ b/scoutos-frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm run build
+EXPOSE 3000
+CMD ["pnpm", "exec", "vite", "preview", "--host", "0.0.0.0", "--port", "3000"]

--- a/scoutos-frontend/index.html
+++ b/scoutos-frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/scoutos-frontend/src/App.tsx
+++ b/scoutos-frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import ChatInterface from './components/ChatInterface';
 import MemoryManager from './components/MemoryManager';
 import LogoutButton from './components/LogoutButton';
@@ -10,6 +10,15 @@ import './index.css';
 function AppContent() {
   const { user } = useUser();
   const [page, setPage] = useState<'chat' | 'memory'>('chat');
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    if (dark) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [dark]);
 
   if (!user) {
     return (
@@ -20,8 +29,14 @@ function AppContent() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-100 flex flex-col items-center p-4">
-      <div className="self-end mb-2">
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 dark:text-gray-100 flex flex-col items-center p-4">
+      <div className="self-end mb-2 flex gap-2">
+        <button
+          className="border rounded px-2 py-1"
+          onClick={() => setDark(d => !d)}
+        >
+          {dark ? 'Light' : 'Dark'} Mode
+        </button>
         <LogoutButton />
       </div>
       <nav className="mb-4 space-x-4">

--- a/scoutos-frontend/src/components/MemoryManager.tsx
+++ b/scoutos-frontend/src/components/MemoryManager.tsx
@@ -23,6 +23,7 @@ export default function MemoryManager() {
   const [mergeSuggestion, setMergeSuggestion] = useState("");
   const [searchTopic, setSearchTopic] = useState("");
   const [searchTag, setSearchTag] = useState("");
+  const [searchContent, setSearchContent] = useState("");
   const [editing, setEditing] = useState<Memory | null>(null);
   const [editContent, setEditContent] = useState("");
   const [editTopic, setEditTopic] = useState("");
@@ -103,6 +104,7 @@ export default function MemoryManager() {
     params.append("user_id", String(user.id));
     if (searchTopic) params.append("topic", searchTopic);
     if (searchTag) params.append("tag", searchTag);
+    if (searchContent) params.append("content", searchContent);
     try {
       const res = await fetch(`${API_URL}/memory/search?${params.toString()}`, {
         headers: user.token ? { Authorization: `Bearer ${user.token}` } : {},
@@ -234,6 +236,7 @@ export default function MemoryManager() {
       </div>
 
       <div className="flex gap-2 mb-4">
+        <input className="border p-2 rounded" placeholder="Search text" value={searchContent} onChange={e => setSearchContent(e.target.value)} />
         <input className="border p-2 rounded" placeholder="Search topic" value={searchTopic} onChange={e => setSearchTopic(e.target.value)} />
         <input className="border p-2 rounded" placeholder="Search tag" value={searchTag} onChange={e => setSearchTag(e.target.value)} />
         <button


### PR DESCRIPTION
## Summary
- support searching memories by content on the backend
- expose the new parameter in docs
- add Docker Compose frontend service and Dockerfile
- implement dark mode toggle and content search in UI
- document new features in README
- include tests for content search

## Testing
- `pytest -q`
- `npm run lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_687358c8760083228c26c994855b76bb