### PR TITLE
Fix AI tag payload

### DIFF
--- a/scoutos-frontend/src/components/MemoryManager.test.tsx
+++ b/scoutos-frontend/src/components/MemoryManager.test.tsx
@@ -35,6 +35,11 @@ describe('MemoryManager API calls', () => {
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/ai/tags'), expect.any(Object))
     })
+    const tagCall = fetchMock.mock.calls.find(c => (c[0] as string).includes('/ai/tags'))
+    expect(tagCall).toBeTruthy()
+    if (tagCall) {
+      expect(JSON.parse((tagCall[1] as RequestInit).body as string)).toEqual({ text: 'foo' })
+    }
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
 

--- a/scoutos-frontend/src/components/MemoryManager.tsx
+++ b/scoutos-frontend/src/components/MemoryManager.tsx
@@ -52,7 +52,7 @@ export default function MemoryManager() {
         'Content-Type': 'application/json',
         ...(user?.token ? { Authorization: `Bearer ${user.token}` } : {}),
       },
-      body: JSON.stringify({ content: contentText }),
+      body: JSON.stringify({ text: contentText }),
     });
     if (res.ok) {
       const data = await res.json();


### PR DESCRIPTION
## Summary
- send `{ text }` instead of `{ content }` when requesting tag suggestions
- verify request body in `MemoryManager` tests

## Testing
- `npm run lint` in `scoutos-frontend`
- `npx vitest run` in `scoutos-frontend`
- `pytest -q` in `scoutos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6873decafbe883229ba9d464ae042470