### PR TITLE
Update merge API usage

### DIFF
--- a/scoutos-frontend/src/components/MemoryManager.test.tsx
+++ b/scoutos-frontend/src/components/MemoryManager.test.tsx
@@ -23,10 +23,15 @@ describe('MemoryManager API calls', () => {
   })
 
   it('requests tags and merge advice', async () => {
+    const memories = [
+      { id: 1, user_id: 1, content: 'a', topic: 't', tags: [], timestamp: '' },
+      { id: 2, user_id: 1, content: 'b', topic: 't', tags: [], timestamp: '' },
+    ]
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) }) // list
-      .mockResolvedValue({ ok: true, json: () => Promise.resolve({ response: 'merge!' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(memories) }) // list
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ tags: [] }) })
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({ verdict: 'merge!' }) })
 
     const { getAllByText, getAllByPlaceholderText, getByText, findByText } = renderWithUser(fetchMock)
 
@@ -42,7 +47,9 @@ describe('MemoryManager API calls', () => {
     await waitFor(() => {
       expect(
         fetchMock.mock.calls.some(
-          c => (c[0] as string).includes('/ai/merge')
+          c =>
+            (c[0] as string).includes('/ai/merge') &&
+            JSON.parse((c[1] as RequestInit).body as string).memory_ids[0] === 1
         )
       ).toBe(true)
     })

--- a/scoutos-frontend/src/components/MemoryManager.tsx
+++ b/scoutos-frontend/src/components/MemoryManager.tsx
@@ -185,31 +185,29 @@ export default function MemoryManager() {
 
   async function requestMergeAdvice() {
     if (!user) return;
-    setLoading(true)
+    setLoading(true);
     try {
+      const ids = memories.slice(0, 2).map(m => m.id);
       const res = await fetch(`${API_URL}/ai/merge`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           ...(user.token ? { Authorization: `Bearer ${user.token}` } : {}),
         },
-        body: JSON.stringify({
-          memory_a: memories[0]?.content || '',
-          memory_b: memories[1]?.content || '',
-        }),
-      })
+        body: JSON.stringify({ memory_ids: ids }),
+      });
       if (res.ok) {
-        const data = await res.json()
-        if (data.response) {
-        setMergeSuggestion(data.response);
-      }
-      toast.success('Merge advice received')
+        const data = await res.json();
+        if (data.verdict) {
+          setMergeSuggestion(data.verdict);
+        }
+        toast.success('Merge advice received');
       } else {
-        const body = await res.json().catch(() => ({}))
-        toast.error(body.detail || 'Request failed')
+        const body = await res.json().catch(() => ({}));
+        toast.error(body.detail || 'Request failed');
       }
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
   }
 


### PR DESCRIPTION
## Summary
- call `/ai/merge` with `memory_ids` instead of content strings
- show the returned `verdict` in MemoryManager
- update unit tests to check request body and verdict display

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6873dece0c788322a9a4fea8eee2b7ff