### PR TITLE
Update Uvicorn Docker config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - UVICORN_RELOAD=--reload
     depends_on:
       - db
   frontend:

--- a/scoutos-backend/Dockerfile
+++ b/scoutos-backend/Dockerfile
@@ -7,4 +7,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app ./app
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# Optional auto-reload can be enabled by setting UVICORN_RELOAD="--reload" at runtime
+ENV UVICORN_RELOAD=""
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port 8000 $UVICORN_RELOAD"]

--- a/scoutos-backend/README.md
+++ b/scoutos-backend/README.md
@@ -17,6 +17,13 @@ Run the API locally with
 uvicorn app.main:app --reload
 ```
 
+When running via Docker, auto-reload can be enabled by setting the
+`UVICORN_RELOAD` environment variable:
+
+```bash
+docker run -e UVICORN_RELOAD="--reload" your-image
+```
+
 The service reads the `DATABASE_URL` environment variable to connect to
 PostgreSQL. The backend uses SQLAlchemy's **sync** engine so the URL must
 use the standard `postgresql://` scheme (not the `postgresql+asyncpg://`


### PR DESCRIPTION
## Summary
- make auto-reload optional in the backend Dockerfile
- document new `UVICORN_RELOAD` variable
- enable reload by default for `docker-compose`

## Testing
- `pytest`
- ❌ `docker build -t scoutos-backend-test ./scoutos-backend` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6873deceddfc8322b1472a6590a0683b