### PR TITLE
Add agent endpoint schemas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,41 @@ If an agent can’t complete a task:
 - ScoutOSAI’s success relies on reliable, transparent, and extensible agent collaboration.
 - Agents: Always be helpful, clear, and secure.
 
+## 10. Current Agent Endpoints
+
+The backend exposes several agent-related routes. Input and output schemas are summarized below. All payloads are JSON.
+
+| Method | Path | Request Schema | Response Schema |
+|-------|------|---------------|----------------|
+|`GET`|`/agent/status`|None|`{"status": "string"}`|
+|`POST`|`/agent/merge`|`{"user_id": int, "memory_ids": [int]}`|`{"memory": {"id": int, "user_id": int, "content": "string", "topic": "string", "tags": ["string"]}}`|
+|`POST`|`/ai/chat`|`{"prompt": "string"}`|`{"response": "string"}`|
+|`POST`|`/ai/tags`|`{"text": "string"}`|`{"tags": ["string"]}`|
+|`POST`|`/ai/merge`|`{"memory_ids": [int]}`|`{"verdict": "string"}`|
+|`POST`|`/ai/summary`|`{"content": "string"}`|`{"summary": "string"}`|
+
+## 11. Example Plugin Manifest
+
+Agents can also be packaged as plugins. A minimal `manifest.json` might look like:
+```json
+{
+  "name": "scoutosai-ai",
+  "description": "Provides AI tagging and chat endpoints",
+  "endpoints": [
+    {"path": "/ai/chat", "method": "POST"},
+    {"path": "/ai/tags", "method": "POST"}
+  ],
+  "env": ["OPENAI_API_KEY"]
+}
+```
+
+## 12. Onboarding Instructions
+
+1. Fork this repository and clone your fork.
+2. Add your agent code under `scoutos-backend` or as an external plugin using the manifest above.
+3. Register any new endpoints and document their schemas in this file.
+4. Open a pull request describing your agent and provide sample usage.
+5. Update the README and other docs to link to your additions.
 ---
 
 **Would you like to add a section for agent “personalities” (e.g., formal, friendly, concise), or want a template for agent-specific markdown files?

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ uvicorn app.main:app --reload
 ```
 
 The service reads `DATABASE_URL` to connect to PostgreSQL (tests override this with SQLite). Set both `FERNET_KEY` and `APP_ENCRYPTION_KEY` to random strings so `Memory.content` can be encrypted. See [`scoutos-backend/README.md`](scoutos-backend/README.md) for more details on environment variables and endpoints.
+Additional agent documentation and plugin examples are in [AGENTS.md](AGENTS.md).
 
 Run the backend unit tests from the same directory:
 
@@ -96,3 +97,5 @@ Review [`SECURITY.md`](SECURITY.md) and your organization’s compliance require
 
 Full details of the REST endpoints, including example requests, can be found in
 [`scoutos-backend/README.md`](scoutos-backend/README.md).
+
+Additional agent documentation and plugin examples are in [AGENTS.md](AGENTS.md).


### PR DESCRIPTION
## Summary
- document agent endpoint schemas
- show example plugin manifest and onboarding steps in `AGENTS.md`
- link README to the expanded agent docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68747167a13c832285657ace9faa57bd