### PR TITLE
Add agent config endpoints and admin UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,13 @@ Add new agent to registry/config (example pseudocode):
 }
 ```
 
+### Registering New Agent Types
+
+Agent metadata is stored in the `agent_configs` table. Create or update a record
+by posting the `name`, `enabled` flag and optional `settings` JSON to
+`/agent/config`. Toggle an agent on or off with `/agent/enable` and retrieve all
+entries using `GET /agent/config`.
+
 ## 7. Checklist for New Agent
 
 - Exposes clear endpoint or hook

--- a/scoutos-backend/app/models/__init__.py
+++ b/scoutos-backend/app/models/__init__.py
@@ -1,0 +1,5 @@
+from .user import User
+from .memory import Memory
+from .agent_config import AgentConfig
+
+__all__ = ["User", "Memory", "AgentConfig"]

--- a/scoutos-backend/app/models/agent_config.py
+++ b/scoutos-backend/app/models/agent_config.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String, Boolean, JSON
+from .base import Base
+
+class AgentConfig(Base):
+    __tablename__ = "agent_configs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+    enabled = Column(Boolean, default=True)
+    settings = Column(JSON, default={})

--- a/scoutos-backend/app/routes/agent.py
+++ b/scoutos-backend/app/routes/agent.py
@@ -3,6 +3,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field
 from typing import Any, List, Dict, Generator
 from app.models.memory import Memory
+from app.models.agent_config import AgentConfig
 from sqlalchemy.orm import Session
 from app.db import SessionLocal
 from app.services.memory_service import MemoryService
@@ -62,3 +63,46 @@ def merge_memories(
     if not merged:
         raise HTTPException(status_code=403, detail="Unauthorized or memories not found")
     return {"memory": _serialize(merged)}
+
+
+class AgentConfigRequest(BaseModel):
+    name: str
+    enabled: bool = True
+    settings: Dict[str, Any] = Field(default_factory=dict)
+
+
+@router.get("/config")
+def list_configs(db: Session = Depends(get_db)) -> List[Dict[str, Any]]:
+    configs = db.query(AgentConfig).all()
+    return [
+        {"name": c.name, "enabled": c.enabled, "settings": c.settings}
+        for c in configs
+    ]
+
+
+@router.post("/config")
+def upsert_config(req: AgentConfigRequest, db: Session = Depends(get_db)) -> Dict[str, str]:
+    config = db.query(AgentConfig).filter_by(name=req.name).first()
+    if config:
+        config.enabled = req.enabled
+        config.settings = req.settings
+    else:
+        config = AgentConfig(name=req.name, enabled=req.enabled, settings=req.settings)
+        db.add(config)
+    db.commit()
+    return {"status": "saved"}
+
+
+class EnableRequest(BaseModel):
+    name: str
+    enabled: bool
+
+
+@router.post("/enable")
+def set_enabled(req: EnableRequest, db: Session = Depends(get_db)) -> Dict[str, str]:
+    config = db.query(AgentConfig).filter_by(name=req.name).first()
+    if not config:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    config.enabled = req.enabled
+    db.commit()
+    return {"status": "updated"}

--- a/scoutos-backend/tests/conftest.py
+++ b/scoutos-backend/tests/conftest.py
@@ -17,6 +17,7 @@ from app.models.base import Base  # noqa: E402
 # Import models so their metadata is registered with Base
 from app.models import user as user_model  # noqa: F401,E402
 from app.models import memory as memory_model  # noqa: F401,E402
+from app.models import agent_config as agent_model  # noqa: F401,E402
 
 # Create all tables for the test database
 Base.metadata.create_all(bind=engine)

--- a/scoutos-backend/tests/test_agent_config.py
+++ b/scoutos-backend/tests/test_agent_config.py
@@ -1,0 +1,33 @@
+from fastapi.testclient import TestClient
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from app.main import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_agent_config_crud():
+    resp = client.get("/agent/config")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+    resp = client.post(
+        "/agent/config",
+        json={"name": "demo", "enabled": True, "settings": {"k": "v"}},
+    )
+    assert resp.status_code == 200
+
+    resp = client.get("/agent/config")
+    assert any(c["name"] == "demo" for c in resp.json())
+
+    resp = client.post(
+        "/agent/enable",
+        json={"name": "demo", "enabled": False},
+    )
+    assert resp.status_code == 200
+
+    resp = client.get("/agent/config")
+    cfg = next(c for c in resp.json() if c["name"] == "demo")
+    assert cfg["enabled"] is False

--- a/scoutos-frontend/src/components/admin/AgentManager.test.tsx
+++ b/scoutos-frontend/src/components/admin/AgentManager.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, type Mock } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import AgentManager from './AgentManager'
+import { UserContext, type User } from '../../context/UserContext'
+
+const user: User = { id: 1, username: 'bob', token: 'tok' }
+
+function renderComp(fetchMock: Mock) {
+  vi.stubGlobal('fetch', fetchMock)
+  return render(
+    <UserContext.Provider value={{ user, setUser: vi.fn() }}>
+      <AgentManager />
+    </UserContext.Provider>
+  )
+}
+
+describe('AgentManager', () => {
+  it('fetches configs on load', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([{ name: 'a', enabled: true, settings: {} }]) })
+    const { findByText } = renderComp(fetchMock)
+    expect(await findByText('a')).toBeTruthy()
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/scoutos-frontend/src/components/admin/AgentManager.tsx
+++ b/scoutos-frontend/src/components/admin/AgentManager.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import { useUser } from '../../hooks/useUser'
+import LoadingSpinner from '../LoadingSpinner'
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+interface AgentConfig {
+  name: string
+  enabled: boolean
+  settings: Record<string, unknown>
+}
+
+export default function AgentManager() {
+  useUser()
+  const [configs, setConfigs] = useState<AgentConfig[]>([])
+  const [loading, setLoading] = useState(false)
+
+  async function loadConfigs() {
+    const res = await fetch(`${API_URL}/agent/config`)
+    if (res.ok) {
+      setConfigs(await res.json())
+    }
+  }
+
+  useEffect(() => {
+    loadConfigs()
+  }, [])
+
+  async function toggle(name: string, enabled: boolean) {
+    setLoading(true)
+    await fetch(`${API_URL}/agent/enable`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, enabled }),
+    })
+    setConfigs(configs.map(c => (c.name === name ? { ...c, enabled } : c)))
+    setLoading(false)
+  }
+
+  return (
+    <div className="p-4 bg-white rounded shadow">
+      <h2 className="text-xl font-semibold mb-2">Agent Config</h2>
+      {loading && <LoadingSpinner />}
+      <ul className="space-y-2">
+        {configs.map(cfg => (
+          <li key={cfg.name} className="flex justify-between border p-2 rounded">
+            <span>{cfg.name}</span>
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={cfg.enabled}
+                onChange={e => toggle(cfg.name, e.target.checked)}
+              />
+              Enabled
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `AgentConfig` model for storing agent metadata
- expose `/agent/config` and `/agent/enable` REST routes for managing agents
- document agent registration workflow in `AGENTS.md`
- add React `AgentManager` admin component
- test new backend endpoints and component

## Testing
- `pnpm exec vitest run`
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68747149d2248322b1b4eb2660e5712c