### PR TITLE
Add roles and TOTP-based 2FA

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ pip install -r requirements.txt -r requirements-dev.txt
 pytest
 ```
 
+### Enabling Two-Factor Authentication
+
+User registration now returns a `totp_secret` value. Scan this key in any TOTP
+app (Google Authenticator, Authy, etc.) and provide the generated code when
+logging in via `/user/login` using the `totp_code` field.
+
 ## Frontend Setup
 
 The React frontend is found in [`scoutos-frontend`](scoutos-frontend/). Use `pnpm` for dependency management:

--- a/scoutos-backend/README.md
+++ b/scoutos-backend/README.md
@@ -58,7 +58,7 @@ purpose.
 | ------ | ---- | ----------- |
 | `GET` | `/` | Health check |
 | `POST` | `/user/register` | Register a user |
-| `POST` | `/user/login` | Obtain auth token |
+| `POST` | `/user/login` | Obtain auth token (TOTP required) |
 | `GET` | `/agent/status` | Agent status placeholder |
 | `POST` | `/agent/merge` | Merge multiple memories |
 | `POST` | `/memory/add` | Store a memory |
@@ -70,10 +70,17 @@ purpose.
 | `POST` | `/ai/tags` | Suggest tags for text |
 | `POST` | `/ai/merge` | LLM merge advice |
 | `POST` | `/ai/summary` | Summarize text |
+| `GET` | `/analytics` | Admin only usage stats |
 
 Authenticate via `/user/login` to obtain a JWT `token`. Pass this token in the
 `Authorization` header as `Bearer <token>` when calling any `/memory` or `/agent`
 route.
+
+### Two-Factor Authentication
+
+`/user/register` returns a `totp_secret` key for the newly created account.
+Add this secret to an authenticator app and pass the current TOTP code as
+`totp_code` when calling `/user/login`.
 
 ### Example Requests
 

--- a/scoutos-backend/app/main.py
+++ b/scoutos-backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routes import memory, user, agent, ai
+from app.routes import memory, user, agent, ai, analytics
 import os
 
 
@@ -28,6 +28,7 @@ app.include_router(memory.router, prefix="/memory")
 app.include_router(user.router, prefix="/user")
 app.include_router(agent.router, prefix="/agent")
 app.include_router(ai.router, prefix="/ai")
+app.include_router(analytics.router, prefix="")
 
 
 @app.get("/")

--- a/scoutos-backend/app/models/user.py
+++ b/scoutos-backend/app/models/user.py
@@ -7,3 +7,5 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String, unique=True)
     password_hash = Column(String)
+    role = Column(String, default="user")
+    totp_secret = Column(String, nullable=True)

--- a/scoutos-backend/app/routes/analytics.py
+++ b/scoutos-backend/app/routes/analytics.py
@@ -1,0 +1,35 @@
+from typing import Dict, Generator
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.orm import Session
+
+from app.db import SessionLocal
+from app.models.user import User
+from app.models.memory import Memory
+from app.services.auth_service import verify_token
+
+security = HTTPBearer()
+
+
+def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)) -> dict:
+    return verify_token(credentials.credentials)
+
+
+router = APIRouter()
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("/analytics")
+def get_analytics(current_user: dict = Depends(get_current_user), db: Session = Depends(get_db)) -> Dict[str, int]:
+    if current_user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin only")
+    users = db.query(User).count()
+    memories = db.query(Memory).count()
+    return {"users": users, "memories": memories}

--- a/scoutos-backend/app/routes/user.py
+++ b/scoutos-backend/app/routes/user.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Generator
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+import pyotp
 from sqlalchemy.orm import Session
 
 from app.db import SessionLocal
@@ -19,24 +20,39 @@ def get_db() -> Generator[Session, None, None]:
         db.close()
 
 
-class UserIn(BaseModel):
+class RegisterUserIn(BaseModel):
     username: str
     password: str
+    role: str | None = "user"
+
+
+class LoginUserIn(BaseModel):
+    username: str
+    password: str
+    totp_code: str
 
 
 @router.post("/register")
-def register(user: UserIn, db: Session = Depends(get_db)) -> Dict[str, Any]:
+def register(user: RegisterUserIn, db: Session = Depends(get_db)) -> Dict[str, Any]:
     service = UserService(db)
     if service.get_by_username(user.username):
         raise HTTPException(status_code=400, detail="Username taken")
     new_user = service.create_user(
-        {"username": user.username, "password": user.password}
+        {
+            "username": user.username,
+            "password": user.password,
+            "role": user.role,
+        }
     )
-    return {"message": "User registered", "id": new_user.id}
+    return {
+        "message": "User registered",
+        "id": new_user.id,
+        "totp_secret": new_user.totp_secret,
+    }
 
 
 @router.post("/login")
-def login(user: UserIn, db: Session = Depends(get_db)) -> Dict[str, Any]:
+def login(user: LoginUserIn, db: Session = Depends(get_db)) -> Dict[str, Any]:
     service = UserService(db)
     db_user = service.get_by_username(user.username)
     if not db_user:
@@ -45,5 +61,8 @@ def login(user: UserIn, db: Session = Depends(get_db)) -> Dict[str, Any]:
         service.pw_hasher.verify(db_user.password_hash, user.password)
     except Exception:
         raise HTTPException(status_code=401, detail="Invalid credentials")
-    token = create_access_token({"sub": str(db_user.id)})
+    totp = pyotp.TOTP(db_user.totp_secret)
+    if not totp.verify(user.totp_code):
+        raise HTTPException(status_code=401, detail="Invalid TOTP code")
+    token = create_access_token({"sub": str(db_user.id), "role": db_user.role})
     return {"message": "Login successful", "id": db_user.id, "token": token}

--- a/scoutos-backend/app/services/user_service.py
+++ b/scoutos-backend/app/services/user_service.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy.orm import Session
 from argon2 import PasswordHasher
+import pyotp
 from app.models.user import User
 
 
@@ -13,10 +14,17 @@ class UserService:
         self.pw_hasher = PasswordHasher()
 
     def create_user(self, user_data: dict) -> User:
-        """Create a new ``User`` with a hashed password."""
+        """Create a new ``User`` with a hashed password and ``role``."""
 
         hashed = self.pw_hasher.hash(user_data["password"])
-        db_user = User(username=user_data["username"], password_hash=hashed)
+        role = user_data.get("role", "user")
+        secret = pyotp.random_base32()
+        db_user = User(
+            username=user_data["username"],
+            password_hash=hashed,
+            role=role,
+            totp_secret=secret,
+        )
         self.db.add(db_user)
         self.db.commit()
         self.db.refresh(db_user)

--- a/scoutos-backend/requirements.txt
+++ b/scoutos-backend/requirements.txt
@@ -11,3 +11,4 @@ argon2-cffi==25.1.0
 starlette==0.46.0
 PyJWT==2.8.0
 cryptography==45.0.5
+pyotp==2.9.0

--- a/scoutos-backend/tests/test_analytics.py
+++ b/scoutos-backend/tests/test_analytics.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+import os, sys, uuid
+import pyotp
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from app.main import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def _auth(role: str = "user"):
+    username = f"u_{uuid.uuid4().hex[:8]}"
+    r = client.post(
+        "/user/register",
+        json={"username": username, "password": "pw", "role": role},
+    )
+    body = r.json()
+    totp = pyotp.TOTP(body["totp_secret"]).now()
+    r = client.post(
+        "/user/login",
+        json={"username": username, "password": "pw", "totp_code": totp},
+    )
+    return body["id"], r.json()["token"]
+
+
+def test_analytics_requires_admin():
+    _, token = _auth()
+    resp = client.get("/analytics", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 403
+
+
+def test_analytics_admin_access():
+    _, token = _auth("admin")
+    resp = client.get("/analytics", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "users" in body and "memories" in body

--- a/scoutos-backend/tests/test_memory.py
+++ b/scoutos-backend/tests/test_memory.py
@@ -8,12 +8,23 @@ client = TestClient(app)
 
 
 
-def _auth():
+import pyotp
+
+
+def _auth(role: str = "user"):
     username = f"u_{uuid.uuid4().hex[:8]}"
     password = "pw"
-    r = client.post("/user/register", json={"username": username, "password": password})
-    user_id = r.json()["id"]
-    r = client.post("/user/login", json={"username": username, "password": password})
+    r = client.post(
+        "/user/register",
+        json={"username": username, "password": password, "role": role},
+    )
+    body = r.json()
+    user_id = body["id"]
+    totp = pyotp.TOTP(body["totp_secret"]).now()
+    r = client.post(
+        "/user/login",
+        json={"username": username, "password": password, "totp_code": totp},
+    )
     token = r.json()["token"]
     return user_id, token
 

--- a/scoutos-backend/tests/test_user.py
+++ b/scoutos-backend/tests/test_user.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 import os, sys, uuid
+import pyotp
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from app.main import app  # noqa: E402
@@ -12,13 +13,17 @@ def test_register_and_login():
     password = "pw"
 
     resp = client.post(
-        "/user/register", json={"username": username, "password": password}
+        "/user/register",
+        json={"username": username, "password": password},
     )
     assert resp.status_code == 200
-    user_id = resp.json()["id"]
+    data = resp.json()
+    user_id = data["id"]
+    totp = pyotp.TOTP(data["totp_secret"]).now()
 
     resp = client.post(
-        "/user/login", json={"username": username, "password": password}
+        "/user/login",
+        json={"username": username, "password": password, "totp_code": totp},
     )
     assert resp.status_code == 200
     body = resp.json()


### PR DESCRIPTION
## Summary
- add `role` and `totp_secret` fields to `User`
- generate TOTP secret on registration and require TOTP code on login
- include user role in JWT tokens
- add admin-only analytics endpoint
- document two-factor authentication
- update tests for 2FA and add analytics tests
- include `pyotp` in dependencies

## Testing
- `pip install -r scoutos-backend/requirements.txt -r scoutos-backend/requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687471633c748322804f8514cd4184f8