### PR TITLE
Add agent chain pipelines

### DIFF
--- a/scoutos-backend/app/main.py
+++ b/scoutos-backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routes import memory, user, agent, ai
+from app.routes import memory, user, agent, ai, chain
 import os
 
 
@@ -28,6 +28,7 @@ app.include_router(memory.router, prefix="/memory")
 app.include_router(user.router, prefix="/user")
 app.include_router(agent.router, prefix="/agent")
 app.include_router(ai.router, prefix="/ai")
+app.include_router(chain.router, prefix="/chain")
 
 
 @app.get("/")

--- a/scoutos-backend/app/models/chain.py
+++ b/scoutos-backend/app/models/chain.py
@@ -1,0 +1,8 @@
+from sqlalchemy import Column, Integer, String, JSON
+from .base import Base
+
+class Chain(Base):
+    __tablename__ = "chains"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+    actions = Column(JSON, nullable=False)

--- a/scoutos-backend/app/routes/chain.py
+++ b/scoutos-backend/app/routes/chain.py
@@ -1,0 +1,56 @@
+from typing import List, Dict, Generator
+
+from typing import List, Dict, Generator
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.db import SessionLocal
+from app.services.chain_service import ChainService
+from app.services.agent_service import AgentService
+
+router = APIRouter()
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+class ChainCreate(BaseModel):
+    name: str
+    actions: List[dict]
+
+
+@router.post("/create")
+async def create_chain(req: ChainCreate, db: Session = Depends(get_db)) -> Dict[str, int]:
+    service = ChainService(db)
+    chain = service.create_chain(req.name, req.actions)
+    return {"id": chain.id}
+
+
+@router.get("/list")
+async def list_chains(db: Session = Depends(get_db)) -> List[Dict]:
+    service = ChainService(db)
+    chains = service.list_chains()
+    return [{"id": c.id, "name": c.name, "actions": c.actions} for c in chains]
+
+
+class ChainRunRequest(BaseModel):
+    chain_id: int
+
+
+@router.post("/run")
+async def run_chain(req: ChainRunRequest, db: Session = Depends(get_db)) -> Dict[str, List]:
+    service = ChainService(db)
+    chain = service.get_chain(req.chain_id)
+    if not chain:
+        raise HTTPException(status_code=404, detail="Chain not found")
+    agent = AgentService()
+    results = await agent.run_pipeline(chain.actions)
+    return {"results": results}
+

--- a/scoutos-backend/app/services/chain_service.py
+++ b/scoutos-backend/app/services/chain_service.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import List
+from sqlalchemy.orm import Session
+
+from app.models.chain import Chain
+
+class ChainService:
+    """Service layer for Chain CRUD operations."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def create_chain(self, name: str, actions: List[dict]) -> Chain:
+        chain = Chain(name=name, actions=actions)
+        self.db.add(chain)
+        self.db.commit()
+        self.db.refresh(chain)
+        return chain
+
+    def list_chains(self) -> List[Chain]:
+        return self.db.query(Chain).all()
+
+    def get_chain(self, chain_id: int) -> Chain | None:
+        return self.db.get(Chain, chain_id)

--- a/scoutos-backend/tests/conftest.py
+++ b/scoutos-backend/tests/conftest.py
@@ -17,6 +17,7 @@ from app.models.base import Base  # noqa: E402
 # Import models so their metadata is registered with Base
 from app.models import user as user_model  # noqa: F401,E402
 from app.models import memory as memory_model  # noqa: F401,E402
+from app.models import chain as chain_model  # noqa: F401,E402
 
 # Create all tables for the test database
 Base.metadata.create_all(bind=engine)

--- a/scoutos-backend/tests/test_chain.py
+++ b/scoutos-backend/tests/test_chain.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from app.main import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_chain_create_list_and_run(monkeypatch):
+    monkeypatch.setenv("AGENT_BACKEND", "local")
+    actions = [{"type": "chat", "prompt": "hello"}]
+    resp = client.post("/chain/create", json={"name": "chain1", "actions": actions})
+    assert resp.status_code == 200
+    chain_id = resp.json()["id"]
+
+    resp = client.get("/chain/list")
+    assert resp.status_code == 200
+    chains = resp.json()
+    assert any(c["id"] == chain_id for c in chains)
+
+    resp = client.post("/chain/run", json={"chain_id": chain_id})
+    assert resp.status_code == 200
+    assert resp.json() == {"results": ["Local model response"]}

--- a/scoutos-backend/tests/test_services.py
+++ b/scoutos-backend/tests/test_services.py
@@ -6,6 +6,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from app.db import SessionLocal  # noqa: E402
 from app.services.user_service import UserService  # noqa: E402
 from app.services.memory_service import MemoryService  # noqa: E402
+from app.services.chain_service import ChainService  # noqa: E402
 
 
 def test_user_service_create_and_get():
@@ -142,5 +143,16 @@ def test_merge_memories_tag_union():
     merged = mem_service.merge_memories([m1.id, m2.id], user.id)
     assert merged.content == "foo\nbar"
     assert set(merged.tags) == {"a", "b", "c"}
+    db.close()
+
+
+def test_chain_service_create_and_list():
+    db = SessionLocal()
+    service = ChainService(db)
+    actions = [{"type": "chat", "prompt": "hi"}]
+    chain = service.create_chain("test", actions)
+    assert chain.id is not None
+    listed = service.list_chains()
+    assert any(c.id == chain.id for c in listed)
     db.close()
 

--- a/scoutos-frontend/src/App.tsx
+++ b/scoutos-frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import ChatInterface from './components/ChatInterface';
 import MemoryManager from './components/MemoryManager';
+import ChainAdmin from './components/ChainAdmin';
 import LogoutButton from './components/LogoutButton';
 import AuthForm from './components/AuthForm';
 import { useUser } from './hooks/useUser';
@@ -9,7 +10,7 @@ import './index.css';
 
 function AppContent() {
   const { user } = useUser();
-  const [page, setPage] = useState<'chat' | 'memory'>('chat');
+  const [page, setPage] = useState<'chat' | 'memory' | 'admin'>('chat');
   const [dark, setDark] = useState(false);
 
   useEffect(() => {
@@ -52,8 +53,14 @@ function AppContent() {
         >
           Memories
         </button>
+        <button
+          className={`px-3 py-1 rounded ${page === 'admin' ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+          onClick={() => setPage('admin')}
+        >
+          Admin
+        </button>
       </nav>
-      {page === 'chat' ? <ChatInterface /> : <MemoryManager />}
+      {page === 'chat' ? <ChatInterface /> : page === 'memory' ? <MemoryManager /> : <ChainAdmin />}
     </div>
   );
 }

--- a/scoutos-frontend/src/components/ChainAdmin.tsx
+++ b/scoutos-frontend/src/components/ChainAdmin.tsx
@@ -1,0 +1,66 @@
+import { useState, useEffect } from 'react'
+import { useUser } from '../hooks/useUser'
+import LoadingSpinner from './LoadingSpinner'
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+interface Chain {
+  id: number
+  name: string
+  actions: unknown[]
+}
+
+export default function ChainAdmin() {
+  const { user } = useUser()
+  const [name, setName] = useState('')
+  const [actions, setActions] = useState<string>('[]')
+  const [chains, setChains] = useState<Chain[]>([])
+  const [loading, setLoading] = useState(false)
+
+  async function loadChains() {
+    const res = await fetch(`${API_URL}/chain/list`)
+    if (res.ok) {
+      setChains(await res.json())
+    }
+  }
+
+  useEffect(() => {
+    loadChains()
+  }, [])
+
+  async function createChain() {
+    setLoading(true)
+    try {
+      const res = await fetch(`${API_URL}/chain/create`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, actions: JSON.parse(actions) })
+      })
+      if (res.ok) {
+        setName('')
+        setActions('[]')
+        loadChains()
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <h2 className="text-xl font-bold mb-2">Chains</h2>
+      <ul className="mb-4 space-y-1">
+        {chains.map(c => (
+          <li key={c.id}>{c.name}</li>
+        ))}
+      </ul>
+      <div className="flex flex-col gap-2">
+        <input className="border p-2 rounded" value={name} onChange={e => setName(e.target.value)} placeholder="Chain name" />
+        <textarea className="border p-2 rounded" rows={4} value={actions} onChange={e => setActions(e.target.value)} placeholder='[{"type":"chat","prompt":"hi"}]' />
+        <button className="bg-blue-600 text-white rounded p-2 flex items-center justify-center gap-2" onClick={createChain} disabled={loading || !user}>
+          {loading && <LoadingSpinner />}Save Chain
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- extend `AgentService` with `run_pipeline`
- support saving chains of actions in backend
- add `/chain` routes and `ChainService`
- include simple admin panel to manage chains in frontend
- test chain functionality

## Testing
- `CI=1 pnpm test`
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6874716b5f10832280075f980bdf3510