### PR TITLE
Add user profile support

### DIFF
--- a/scoutos-backend/README.md
+++ b/scoutos-backend/README.md
@@ -59,6 +59,8 @@ purpose.
 | `GET` | `/` | Health check |
 | `POST` | `/user/register` | Register a user |
 | `POST` | `/user/login` | Obtain auth token |
+| `GET` | `/user/profile` | Get user profile |
+| `PUT` | `/user/profile` | Update user profile |
 | `GET` | `/agent/status` | Agent status placeholder |
 | `POST` | `/agent/merge` | Merge multiple memories |
 | `POST` | `/memory/add` | Store a memory |

--- a/scoutos-backend/app/models/user_profile.py
+++ b/scoutos-backend/app/models/user_profile.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, Integer, ForeignKey, JSON
+from .base import Base
+
+
+class UserProfile(Base):
+    __tablename__ = "user_profiles"
+
+    user_id = Column(Integer, ForeignKey("users.id"), primary_key=True)
+    preferences = Column(JSON, default={})

--- a/scoutos-backend/app/routes/user.py
+++ b/scoutos-backend/app/routes/user.py
@@ -1,14 +1,17 @@
 from typing import Any, Dict, Generator
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.db import SessionLocal
-from app.services.auth_service import create_access_token
+from app.services.auth_service import create_access_token, verify_token
 from app.services.user_service import UserService
+from app.services.user_profile_service import UserProfileService
 
 router = APIRouter()
+security = HTTPBearer()
 
 
 def get_db() -> Generator[Session, None, None]:
@@ -22,6 +25,17 @@ def get_db() -> Generator[Session, None, None]:
 class UserIn(BaseModel):
     username: str
     password: str
+
+
+class ProfileIn(BaseModel):
+    user_id: int
+    preferences: Dict[str, Any]
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> Dict[str, Any]:
+    return verify_token(credentials.credentials)
 
 
 @router.post("/register")
@@ -47,3 +61,33 @@ def login(user: UserIn, db: Session = Depends(get_db)) -> Dict[str, Any]:
         raise HTTPException(status_code=401, detail="Invalid credentials")
     token = create_access_token({"sub": str(db_user.id)})
     return {"message": "Login successful", "id": db_user.id, "token": token}
+
+
+@router.get("/profile")
+def get_profile(
+    user_id: int,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    if user_id != int(current_user["sub"]):
+        raise HTTPException(status_code=403, detail="Unauthorized")
+    service = UserProfileService(db)
+    profile = service.get_profile(user_id)
+    prefs = profile.preferences if profile else {}
+    return {"user_id": user_id, "preferences": prefs}
+
+
+@router.put("/profile")
+def update_profile(
+    payload: ProfileIn,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    if payload.user_id != int(current_user["sub"]):
+        raise HTTPException(status_code=403, detail="Unauthorized")
+    service = UserProfileService(db)
+    profile = service.update_profile(payload.user_id, payload.preferences)
+    return {
+        "message": "Profile updated",
+        "profile": {"user_id": profile.user_id, "preferences": profile.preferences},
+    }

--- a/scoutos-backend/app/services/user_profile_service.py
+++ b/scoutos-backend/app/services/user_profile_service.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Session
+
+from app.models.user_profile import UserProfile
+
+
+class UserProfileService:
+    """Service for creating and updating ``UserProfile`` rows."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def get_profile(self, user_id: int) -> UserProfile | None:
+        return self.db.query(UserProfile).filter(UserProfile.user_id == user_id).first()
+
+    def update_profile(self, user_id: int, preferences: dict) -> UserProfile:
+        profile = self.get_profile(user_id)
+        if profile is None:
+            profile = UserProfile(user_id=user_id, preferences=preferences)
+            self.db.add(profile)
+        else:
+            profile.preferences = preferences
+        self.db.commit()
+        self.db.refresh(profile)
+        return profile

--- a/scoutos-backend/tests/conftest.py
+++ b/scoutos-backend/tests/conftest.py
@@ -17,6 +17,7 @@ from app.models.base import Base  # noqa: E402
 # Import models so their metadata is registered with Base
 from app.models import user as user_model  # noqa: F401,E402
 from app.models import memory as memory_model  # noqa: F401,E402
+from app.models import user_profile as user_profile_model  # noqa: F401,E402
 
 # Create all tables for the test database
 Base.metadata.create_all(bind=engine)

--- a/scoutos-backend/tests/test_user.py
+++ b/scoutos-backend/tests/test_user.py
@@ -7,6 +7,15 @@ from app.main import app  # noqa: E402
 client = TestClient(app)
 
 
+def _auth():
+    username = f"u_{uuid.uuid4().hex[:8]}"
+    password = "pw"
+    r = client.post("/user/register", json={"username": username, "password": password})
+    user_id = r.json()["id"]
+    r = client.post("/user/login", json={"username": username, "password": password})
+    token = r.json()["token"]
+    return user_id, token
+
 def test_register_and_login():
     username = f"u_{uuid.uuid4().hex[:8]}"
     password = "pw"
@@ -24,3 +33,48 @@ def test_register_and_login():
     body = resp.json()
     assert body["id"] == user_id
     assert "token" in body
+
+def test_profile_get_and_put():
+    user_id, token = _auth()
+    resp = client.get(
+        "/user/profile",
+        params={"user_id": user_id},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"user_id": user_id, "preferences": {}}
+
+    data = {"user_id": user_id, "preferences": {"theme": "dark", "notify": True}}
+    resp = client.put(
+        "/user/profile",
+        json=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["profile"]["preferences"]["theme"] == "dark"
+
+    resp = client.get(
+        "/user/profile",
+        params={"user_id": user_id},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.json()["preferences"]["theme"] == "dark"
+
+
+def test_profile_unauthorized():
+    user_id, token = _auth()
+    other_id, other_token = _auth()
+
+    resp = client.get(
+        "/user/profile",
+        params={"user_id": user_id},
+        headers={"Authorization": f"Bearer {other_token}"},
+    )
+    assert resp.status_code == 403
+
+    resp = client.put(
+        "/user/profile",
+        json={"user_id": user_id, "preferences": {}},
+        headers={"Authorization": f"Bearer {other_token}"},
+    )
+    assert resp.status_code == 403

--- a/scoutos-frontend/src/App.tsx
+++ b/scoutos-frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import ChatInterface from './components/ChatInterface';
 import MemoryManager from './components/MemoryManager';
+import ProfileEditor from './components/ProfileEditor';
 import LogoutButton from './components/LogoutButton';
 import AuthForm from './components/AuthForm';
 import { useUser } from './hooks/useUser';
@@ -9,7 +10,7 @@ import './index.css';
 
 function AppContent() {
   const { user } = useUser();
-  const [page, setPage] = useState<'chat' | 'memory'>('chat');
+  const [page, setPage] = useState<'chat' | 'memory' | 'profile'>('chat');
   const [dark, setDark] = useState(false);
 
   useEffect(() => {
@@ -52,8 +53,14 @@ function AppContent() {
         >
           Memories
         </button>
+        <button
+          className={`px-3 py-1 rounded ${page === 'profile' ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+          onClick={() => setPage('profile')}
+        >
+          Profile
+        </button>
       </nav>
-      {page === 'chat' ? <ChatInterface /> : <MemoryManager />}
+      {page === 'chat' ? <ChatInterface /> : page === 'memory' ? <MemoryManager /> : <ProfileEditor />}
     </div>
   );
 }

--- a/scoutos-frontend/src/components/ProfileEditor.tsx
+++ b/scoutos-frontend/src/components/ProfileEditor.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { useUser } from '../hooks/useUser';
+import LoadingSpinner from './LoadingSpinner';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
+interface Preferences {
+  theme: 'light' | 'dark';
+  notify: boolean;
+}
+
+export default function ProfileEditor() {
+  const { user } = useUser();
+  const [prefs, setPrefs] = useState<Preferences>({ theme: 'light', notify: true });
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    async function fetchProfile() {
+      if (!user) return;
+      const res = await fetch(`${API_URL}/user/profile?user_id=${user.id}`, {
+        headers: user.token ? { Authorization: `Bearer ${user.token}` } : {},
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.preferences) {
+          setPrefs({ theme: data.preferences.theme || 'light', notify: data.preferences.notify ?? true });
+        }
+      }
+    }
+    fetchProfile();
+  }, [user]);
+
+  async function save() {
+    if (!user) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_URL}/user/profile`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(user.token ? { Authorization: `Bearer ${user.token}` } : {}),
+        },
+        body: JSON.stringify({ user_id: user.id, preferences: prefs }),
+      });
+      if (res.ok) {
+        toast.success('Profile saved');
+      } else {
+        const body = await res.json().catch(() => ({}));
+        toast.error(body.detail || 'Failed to save');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow p-4 max-w-sm">
+      <h2 className="text-xl font-semibold mb-2">Profile</h2>
+      <div className="flex flex-col gap-3">
+        <label className="flex justify-between items-center">
+          Theme
+          <select
+            className="border p-2 rounded"
+            value={prefs.theme}
+            onChange={e => setPrefs({ ...prefs, theme: e.target.value as Preferences['theme'] })}
+          >
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={prefs.notify}
+            onChange={e => setPrefs({ ...prefs, notify: e.target.checked })}
+          />
+          Enable Notifications
+        </label>
+        <button
+          className="bg-blue-600 text-white rounded p-2 flex items-center justify-center gap-2"
+          onClick={save}
+          disabled={loading}
+        >
+          {loading && <LoadingSpinner />}
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `UserProfile` model and service
- expose `/user/profile` GET/PUT endpoints
- document new endpoints in backend README
- create React `ProfileEditor` component
- add navigation entry and tests for profile features

## Testing
- `npm run lint`
- `pnpm test -- --run`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6874715f69608322b8de4b38f1eb67de