### PR TITLE
Remove duplicate OPENAI_API_KEY in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ export POSTGRES_PASSWORD=yourpassword
 export OPENAI_API_KEY=sk-...
 export FERNET_KEY=$(python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
 export APP_ENCRYPTION_KEY=$(python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
-export OPENAI_API_KEY=sk-...
 docker-compose up
 ```
 


### PR DESCRIPTION
## Summary
- tidy README setup snippet by removing a redundant `OPENAI_API_KEY` export

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68747bbaa28c8322bb5d1d3347d762ee