### PR TITLE
Add dockerignore to backend and frontend

### DIFF
--- a/scoutos-backend/.dockerignore
+++ b/scoutos-backend/.dockerignore
@@ -1,0 +1,11 @@
+node_modules/
+tests/
+dist/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+*.db
+.env
+build/
+test.db
+.git

--- a/scoutos-frontend/.dockerignore
+++ b/scoutos-frontend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules/
+tests/
+dist/
+.vite-cache/
+coverage/
+.env*
+*.log
+build/
+.vscode/
+.git


### PR DESCRIPTION
## Summary
- shrink Docker build contexts by ignoring node modules, tests, dist and more

## Testing
- `pytest -q`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68747c70acd88322bdaf97de700a01c3