### PR TITLE
Fix CI build option

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,5 +38,5 @@ jobs:
         cache: 'pnpm'
         cache-dependency-path: scoutos-frontend/pnpm-lock.yaml
     - run: pnpm install --frozen-lockfile
-    - run: pnpm run build --if-present
+    - run: pnpm run --if-present build
     - run: pnpm test --if-present


### PR DESCRIPTION
## Summary
- adjust Node.js workflow command so that `--if-present` is passed to pnpm, not Vite

## Testing
- `pytest`
- `pnpm test -- --run`
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_687493bb22948322a67a10d0985e5f60