### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   setup-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/asr319/ScoutOSAI/security/code-scanning/6](https://github.com/asr319/ScoutOSAI/security/code-scanning/6)

To resolve the issue, we will add an explicit `permissions` block to the root of the workflow file. This block will enforce the principle of least privilege by granting only the permissions necessary for the current workflow tasks. Based on the existing steps, the workflow primarily requires read access to repository contents for the `actions/checkout` step. Therefore, we will set `contents: read` permissions at the workflow level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
