### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scan-secrets.yml
+++ b/.github/workflows/scan-secrets.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   gitleaks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/asr319/ScoutOSAI/security/code-scanning/7](https://github.com/asr319/ScoutOSAI/security/code-scanning/7)

To resolve the issue, we will add a `permissions` key at the root level of the workflow file. This will apply the permissions to all jobs within the workflow. Since the workflow only performs read operations (checking out code and scanning for secrets) and outputs a success message, the `contents: read` permission is sufficient. This explicitly limits the workflow's access to only what is necessary, following the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
