### PR TITLE
Add GitHub Pages workflow and env docs

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy ScoutOS Frontend to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm install -g pnpm corepack
+      - name: Install frontend dependencies
+        run: |
+          cd scoutos-frontend
+          pnpm install
+      - name: Set build environment variables
+        run: |
+          cd scoutos-frontend
+          echo "VITE_API_URL=https://your-backend-endpoint.com" >> .env
+          echo "VITE_ENV=production" >> .env
+          echo "VITE_USE_MOCK_AI=false" >> .env
+          echo "SCOUTOS_CUSTOM_DOMAIN=dev.scoutos.local" >> .env
+          echo "SCOUTOS_ALLOWED_DOMAINS=localhost,127.0.0.1,scoutos.local,asr319.github.io,dev.scoutos.local,api.openai.com,registry.npmjs.org,pypi.org,pnpm.io,vitest.dev,github.com,files.pythonhosted.org" >> .env
+      - name: Build static site
+        run: |
+          cd scoutos-frontend
+          pnpm run build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: scoutos-frontend/dist

--- a/README.md
+++ b/README.md
@@ -36,15 +36,16 @@ ScoutOSAI relies on several environment variables for configuration:
 - `SECRET_KEY` – signing key for JWT tokens.
 - `ALLOWED_ORIGINS` – comma-separated CORS origins.
 - `AGENT_BACKEND` – set to `local` to disable OpenAI calls.
-- `VITE_API_URL` and `VITE_USE_MOCK` – frontend configuration.
+- `VITE_API_URL` – URL to the backend API.
+- `VITE_USE_MOCK` or `VITE_USE_MOCK_AI` – enable the mock API during local development.
+- `VITE_ENV` – build environment identifier (`development` or `production`).
+- `SCOUTOS_CUSTOM_DOMAIN` – domain name for GitHub Pages or local testing.
+- `SCOUTOS_ALLOWED_DOMAINS` – comma-separated list of allowed hosts for network calls.
 
 Sample `.env` files include these variables with placeholder values.
 
 The backend service uses these values when constructing `DATABASE_URL` and when
 calling the OpenAI API for the demo AI endpoints.
-
-The compose file also builds the React frontend so the full stack runs with a
-single command. Visit `http://localhost:3000` after running `docker-compose up`.
 
 The compose file also builds the React frontend so the full stack runs with a
 single command. Visit `http://localhost:3000` after running `docker-compose up`.
@@ -93,11 +94,15 @@ cd scoutos-frontend
 pnpm install
 ```
 
-Create a `.env` file with the backend URL:
+Copy `scoutos-frontend/.env.example` to `.env` and adjust as needed:
 
 ```
 VITE_API_URL=http://localhost:8000
+VITE_ENV=development
+VITE_USE_MOCK_AI=true
 VITE_USE_MOCK=true
+SCOUTOS_CUSTOM_DOMAIN=dev.scoutos.local
+SCOUTOS_ALLOWED_DOMAINS=localhost,127.0.0.1,scoutos.local,asr319.github.io,dev.scoutos.local,api.openai.com,registry.npmjs.org,pypi.org,pnpm.io,vitest.dev,github.com,files.pythonhosted.org
 ```
 
 Start the development server with:

--- a/scoutos-frontend/.env.example
+++ b/scoutos-frontend/.env.example
@@ -1,2 +1,12 @@
-VITE_API_URL=http://localhost:8000
+# Example development variables for Vite/React build
+VITE_API_URL=https://your-backend-dev-or-prod-endpoint.com
+VITE_ENV=development
+VITE_USE_MOCK_AI=true
+# Legacy variable for compatibility with existing scripts
 VITE_USE_MOCK=true
+SCOUTOS_CUSTOM_DOMAIN=dev.scoutos.local
+SCOUTOS_ALLOWED_DOMAINS=localhost,127.0.0.1,scoutos.local,asr319.github.io,dev.scoutos.local,api.openai.com,registry.npmjs.org,pypi.org,pnpm.io,vitest.dev,github.com,files.pythonhosted.org
+
+# For local builds:
+# Copy .env.example to .env and customize as needed for dev/test.
+# Vite will inject any VITE_* variables into your frontend at build time.

--- a/scoutos-frontend/README.md
+++ b/scoutos-frontend/README.md
@@ -9,12 +9,16 @@ the backend API and provides a simple chat interface.
 pnpm install
 ```
 
-During development the app expects the backend URL in `VITE_API_URL`.
-Create a `.env` file and set:
+During development the app expects several environment variables. Copy
+`.env.example` to `.env` and adjust as needed:
 
 ```
 VITE_API_URL=http://localhost:8000
+VITE_ENV=development
+VITE_USE_MOCK_AI=true
 VITE_USE_MOCK=true
+SCOUTOS_CUSTOM_DOMAIN=dev.scoutos.local
+SCOUTOS_ALLOWED_DOMAINS=localhost,127.0.0.1,scoutos.local,asr319.github.io,dev.scoutos.local,api.openai.com,registry.npmjs.org,pypi.org,pnpm.io,vitest.dev,github.com,files.pythonhosted.org
 ```
 
 Run the development server with
@@ -28,8 +32,9 @@ pnpm run dev
 The built site is static and can be deployed on Vercel, Netlify or Railway.
 Ensure the `VITE_API_URL` environment variable points to your deployed backend.
 
-Set `VITE_USE_MOCK=true` to enable the built-in mock API responses. This allows
-the UI to run without a backend during development or testing.
+Set `VITE_USE_MOCK=true` or `VITE_USE_MOCK_AI=true` to enable the built-in mock
+API responses. This allows the UI to run without a backend during development or
+testing.
 
 ## Linting and Tests
 

--- a/scoutos-frontend/src/index.min.css
+++ b/scoutos-frontend/src/index.min.css
@@ -1,0 +1,1 @@
+@tailwind base;@tailwind components;@tailwind utilities;


### PR DESCRIPTION
## Summary
- add pages-deploy workflow for GitHub Pages static builds
- document public environment variables in README
- provide updated `.env.example` for the frontend
- expand frontend README with variable usage
- add minified index.css

All CI/CD, security, and agent checks passed.

------
https://chatgpt.com/codex/tasks/task_e_687591fe82c88322a88715fa64ff0dfc