### PR TITLE
Fix dev-test workflow pnpm setup

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -37,6 +37,12 @@ jobs:
           echo "DATABASE_URL=$DATABASE_URL"
           echo "BEKONOS_ALLOWED_DOMAINS=$BEKONOS_ALLOWED_DOMAINS"
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+          run_install: false
+
       - name: Set up Node.js and pnpm
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- install pnpm before running `setup-node` in the dev-test workflow

## Testing
- `pytest`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68770622ffc08322b58d509c569fe357