### PR TITLE
Fix Prettier check in CI

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+node_modules
+.vite/
+bekonos-backend/test.db
+.pytest_cache/
+dist/
+*.min.js
+*.min.css


### PR DESCRIPTION
## Summary
- add `.prettierignore` so Prettier skips caches and minified files

## Testing
- `pip install -r bekonos-backend/requirements.txt -r bekonos-backend/requirements-dev.txt`
- `pnpm install` within `bekonos-frontend`
- `pytest bekonos-backend/tests`
- `pnpm test -- --run` within `bekonos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_68770a6c1dfc8322892a3c7cec2601e3