### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,6 +5,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/asr319/bekonOS/security/code-scanning/26](https://github.com/asr319/bekonOS/security/code-scanning/26)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Based on the provided workflow, it primarily checks out the repository, sets up Node.js, installs dependencies, and builds the project. These tasks only require `contents: read` permissions. If additional write permissions are needed in the future (e.g., for pull requests or issues), they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
