### PR TITLE
Add docs index for GitHub Pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: bekonOS Documentation
+---
+
+# bekonOS Documentation
+
+Welcome to the bekonOS docs. Here you'll find resources about using the platform.
+


### PR DESCRIPTION
## Summary
- add an `index.md` inside `docs/` so Jekyll can build the site

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pnpm install`
- `python scripts/check_duplicates.py`
- `npx prettier --write .`
- `pytest`
- `pnpm test -- --run`
- `pip-audit`
- `pnpm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_68771b4ed91c8322803c6696da73ee55