### PR TITLE
Fix broken logo path

### DIFF
--- a/bekonos-frontend/index.html
+++ b/bekonos-frontend/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/bekonos_logo_fullsize.svg" />
-    <link rel="apple-touch-icon" href="/bekonos_logo_fullsize.svg" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="icon" type="image/svg+xml" href="bekonos_logo_fullsize.svg" />
+    <link rel="apple-touch-icon" href="bekonos_logo_fullsize.svg" />
+    <link rel="manifest" href="manifest.json" />
     <meta name="theme-color" content="#20467A" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>bekonOS</title>

--- a/bekonos-frontend/public/manifest.json
+++ b/bekonos-frontend/public/manifest.json
@@ -7,12 +7,12 @@
   "theme_color": "#20467A",
   "icons": [
     {
-      "src": "/bekonos_logo_fullsize.svg",
+      "src": "bekonos_logo_fullsize.svg",
       "sizes": "192x192",
       "type": "image/svg+xml"
     },
     {
-      "src": "/bekonos_logo_fullsize.svg",
+      "src": "bekonos_logo_fullsize.svg",
       "sizes": "512x512",
       "type": "image/svg+xml"
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,4 +6,3 @@ title: bekonOS Documentation
 # bekonOS Documentation
 
 Welcome to the bekonOS docs. Here you'll find resources about using the platform.
-


### PR DESCRIPTION
## Summary
- use relative paths for logo references in the web frontend
- format docs index

## Testing
- `pip install -r bekonos-backend/requirements.txt -r bekonos-backend/requirements-dev.txt`
- `pnpm install`
- `python scripts/check_duplicates.py`
- `npx prettier --write .`
- `pnpm lint`
- `pnpm test -- --run`
- `pnpm audit`
- `pytest`
- `pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_6877322a172c8322aab61ffd587948ca