### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/bekonos-frontend/vite.config.ts
+++ b/bekonos-frontend/vite.config.ts
@@ -4,6 +4,9 @@ import { VitePWA } from "vite-plugin-pwa";
 
 // https://vite.dev/config/
 export default defineConfig({
+  // When deploying to GitHub Pages the site is served from `/bekonOS`.
+  // Setting the base path ensures asset URLs resolve correctly.
+  base: "/bekonOS/",
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- configure Vite build to use `/bekonOS/` as the base path so assets load correctly on GitHub Pages

All CI/CD, security, and agent checks passed.


------
https://chatgpt.com/codex/tasks/task_e_6877383aa1488322afc22a47dd29eb92